### PR TITLE
Support batch_size per class

### DIFF
--- a/docs/en/configuration.md
+++ b/docs/en/configuration.md
@@ -15,6 +15,7 @@ SilverStripe\Forager\Service\IndexConfiguration:
     myindex:
       includeClasses:
         SilverStripe\CMS\Model\SiteTree:
+          batch_size: 50
           fields:
             title:
               property: Title
@@ -35,6 +36,9 @@ should have the `SearchServiceExtension` applied, however. This is discussed fur
 
 * `SilverStripe\CMS\Model\SiteTree`: This class already has the necessary extension applied
 to it as a default configuration from the module
+
+* `batch_size`: This batch size definition specifically applies when we are queueing jobs for this class and index. If 
+no class specific batch size is defined, then the default batch size will be used
 
 * `fields`: The fields you want to index. This is a map of the _search field name_ as the key
 (how you want it to be listed in your search index) to either a boolean, or another map
@@ -119,8 +123,8 @@ Use cases:
 * Some services include rate limits. You could use this feature to effectively "slow down" your processing of records
 
 * Some classes can be quite process intensive (EG: Files that require you to load them into memory in order to send
-them to your service provider). This "cooldown", plus `batch_sizes` should provide you with some dials to turn to try 
-and reduce the impact that reindexing has on your application
+them to your service provider). This "cooldown", plus `batch_sizes` at a class level, should provide you with some dials
+to turn to try and reduce the impact that reindexing has on your application
 
 ## Advanced configuration
 

--- a/src/Jobs/BatchJob.php
+++ b/src/Jobs/BatchJob.php
@@ -3,6 +3,7 @@
 namespace SilverStripe\Forager\Jobs;
 
 use SilverStripe\Core\Config\Configurable;
+use SilverStripe\Forager\Service\IndexConfiguration;
 use Symbiote\QueuedJobs\Services\AbstractQueuedJob;
 use Symbiote\QueuedJobs\Services\QueuedJob;
 
@@ -30,6 +31,45 @@ abstract class BatchJob extends AbstractQueuedJob implements QueuedJob
         $cooldown *= 1000;
 
         usleep($cooldown);
+    }
+
+    protected function getIndexConfigurationBatchSize(?array $onlyClasses = null, ?array $onlyIndexes = null): int
+    {
+        $indexConfiguration = IndexConfiguration::singleton();
+
+        // If no specific classes or indexes have been requested, then we should use the lowest defined batch size
+        // across all of our configuration
+        if (!$onlyClasses && !$onlyIndexes) {
+            return $indexConfiguration->getLowestBatchSize();
+        }
+
+        if ($onlyIndexes) {
+            // If we've requested to only reindex a specific index, then set this limitation on our IndexConfiguration
+            $indexConfiguration->setOnlyIndexes($onlyIndexes);
+        }
+
+        if (!$onlyClasses) {
+            // We haven't limited this request to any specific classes, so just get the lowest batch size that we can
+            // find within our index configuration (it will be affected by the above $onlyIndexes filter)
+            return $indexConfiguration->getLowestBatchSize();
+        }
+
+        // There is a request to only include certain classes, so let's find out what the lowest batch size is for
+        // those requested classes
+        $batchSizes = [];
+
+        foreach ($onlyClasses as $class) {
+            // This will get either the defined batch size for the class, or the default batch size
+            $batchSizes[] = $indexConfiguration->getLowestBatchSizeForClass($class);
+        }
+
+        if ($batchSizes) {
+            // If we were able to find any batch size definitions, then return the lowest
+            return min($batchSizes);
+        }
+
+        // If all else fails, return the lowest batch size across all of our configuration
+        return $indexConfiguration->getLowestBatchSize();
     }
 
 }

--- a/src/Jobs/ClearIndexJob.php
+++ b/src/Jobs/ClearIndexJob.php
@@ -10,7 +10,6 @@ use SilverStripe\Core\Injector\Injectable;
 use SilverStripe\Core\Injector\Injector;
 use SilverStripe\Forager\Interfaces\BatchDocumentRemovalInterface;
 use SilverStripe\Forager\Interfaces\IndexingInterface;
-use SilverStripe\Forager\Service\IndexConfiguration;
 use SilverStripe\Forager\Service\Traits\ServiceAware;
 
 /**
@@ -36,7 +35,8 @@ class ClearIndexJob extends BatchJob
             return;
         }
 
-        $batchSize = $batchSize ?: IndexConfiguration::singleton()->getBatchSize();
+        // Use the provided batch size, or determine batch size from our IndexConfiguration
+        $batchSize = $batchSize ?: $this->getIndexConfigurationBatchSize(null, [$indexName]);
 
         $this->setIndexName($indexName);
         $this->setBatchSize($batchSize);

--- a/src/Jobs/IndexJob.php
+++ b/src/Jobs/IndexJob.php
@@ -6,7 +6,6 @@ use Exception;
 use SilverStripe\Core\Extensible;
 use SilverStripe\Core\Injector\Injectable;
 use SilverStripe\Forager\Interfaces\DocumentInterface;
-use SilverStripe\Forager\Service\IndexConfiguration;
 use SilverStripe\Forager\Service\Indexer;
 use Symbiote\QueuedJobs\Services\QueuedJob;
 
@@ -35,7 +34,8 @@ class IndexJob extends BatchJob
         ?int $batchSize = null,
         bool $processDependencies = true
     ) {
-        $batchSize = $batchSize ?: IndexConfiguration::singleton()->getBatchSize();
+        // Use the provided batch size, or determine batch size from our IndexConfiguration
+        $batchSize = $batchSize ?: $this->getIndexConfigurationBatchSize();
 
         $this->setDocuments($documents);
         $this->setMethod($method);

--- a/src/Jobs/ReindexJob.php
+++ b/src/Jobs/ReindexJob.php
@@ -44,7 +44,8 @@ class ReindexJob extends BatchJob
     {
         parent::__construct();
 
-        $batchSize = $batchSize ?: IndexConfiguration::singleton()->getBatchSize();
+        // Use the provided batch size, or determine batch size from our IndexConfiguration
+        $batchSize = $batchSize ?: $this->getIndexConfigurationBatchSize($onlyClasses, $onlyIndexes);
 
         $this->setOnlyClasses($onlyClasses);
         $this->setOnlyIndexes($onlyIndexes);

--- a/src/Tasks/SearchReindex.php
+++ b/src/Tasks/SearchReindex.php
@@ -48,14 +48,40 @@ class SearchReindex extends BuildTask
         Environment::increaseMemoryLimitTo();
         Environment::increaseTimeLimitTo();
 
-        $targetClass = $request->getVar('onlyClass');
-        $targetIndex = $request->getVar('onlyIndex');
-        $job = ReindexJob::create($targetClass ? [$targetClass] : null, $targetIndex ? [$targetIndex] : null);
+        $indexConfiguration = IndexConfiguration::singleton();
 
-        if ($this->getConfiguration()->shouldUseSyncJobs()) {
-            SyncJobRunner::singleton()->runJob($job, false);
-        } else {
-            QueuedJobService::singleton()->queueJob($job);
+        $onlyClass = $request->getVar('onlyClass');
+        $onlyIndex = $request->getVar('onlyIndex');
+
+        if ($onlyIndex) {
+            // If we've requested to only reindex a specific index, then set this limitation on our IndexConfiguration
+            $indexConfiguration->setOnlyIndexes([$onlyIndex]);
+        }
+
+        // Loop through all available indexes (with the above filter applied, if relevant)
+        foreach (array_keys($indexConfiguration->getIndexes()) as $index) {
+            // If a specific class has been requested, then we'll limit ourselves to that, otherwise get all classes
+            // for the index
+            $classes = $onlyClass
+                ? [$onlyClass]
+                : $indexConfiguration->getClassesForIndex($index);
+
+            foreach ($classes as $class) {
+                // Find our desired batch size for that class. This will either be the batch_size that you have defined
+                // in the class configuration, or the default batch size
+                $batchSize = $indexConfiguration->getLowestBatchSizeForClass($class, $index);
+
+                // Create a job for this class and index
+                $job = ReindexJob::create([$class], [$index], $batchSize);
+
+                if ($this->getConfiguration()->shouldUseSyncJobs()) {
+                    // Run the job immediately
+                    SyncJobRunner::singleton()->runJob($job, false);
+                } else {
+                    // Queue the job for processing
+                    QueuedJobService::singleton()->queueJob($job);
+                }
+            }
         }
     }
 

--- a/tests/DataObject/DataObjectDocumentTest.php
+++ b/tests/DataObject/DataObjectDocumentTest.php
@@ -8,6 +8,7 @@ use SilverStripe\Forager\Exception\IndexConfigurationException;
 use SilverStripe\Forager\Interfaces\DocumentAddHandler;
 use SilverStripe\Forager\Interfaces\DocumentRemoveHandler;
 use SilverStripe\Forager\Schema\Field;
+use SilverStripe\Forager\Service\IndexConfiguration;
 use SilverStripe\Forager\Service\Indexer;
 use SilverStripe\Forager\Tests\Fake\DataObjectFake;
 use SilverStripe\Forager\Tests\Fake\DataObjectFakePrivate;
@@ -185,14 +186,13 @@ class DataObjectDocumentTest extends SearchServiceTest
     public function testSubsiteDataObjectShouldIndex(): void
     {
         $subsite2 = $this->objFromFixture(Subsite::class, 'subsite2');
-
-        $config = $this->mockConfig();
+        $this->mockConfig();
 
         // Mocked indexes:
         //  - index0: allows all data without subsite filter
         //  - index1: for subsite2 and Page class and Data object that does not implement subsite
         //  - index2: for subsite2 and Data object that does not implement subsite
-        $config->set(
+        IndexConfiguration::config()->set(
             'indexes',
             [
                 'index0' => [

--- a/tests/Fake/IndexConfigurationFake.php
+++ b/tests/Fake/IndexConfigurationFake.php
@@ -40,35 +40,7 @@ class IndexConfigurationFake extends IndexConfiguration
 
     public function getIndexes(): array
     {
-        $indexes = $this->override['indexes'] ?? null;
-
-        if (!$indexes) {
-            return parent::getIndexes();
-        }
-
-        // Convert environment variable defined in YML config to its value
-        array_walk($indexes, function (array &$configuration): void {
-            $configuration = $this->environmentVariableToValue($configuration);
-        });
-
-        // Using reflection because we don't want this property to be part of the public API, but we need access to it
-        // for testing purposes
-        $reflectionProperty = new ReflectionProperty(IndexConfiguration::class, 'onlyIndexes');
-        $reflectionProperty->setAccessible(true);
-
-        $onlyIndexes = $reflectionProperty->getValue($this);
-
-        if (!$onlyIndexes) {
-            return $indexes;
-        }
-
-        foreach (array_keys($indexes) as $index) {
-            if (!in_array($index, $onlyIndexes)) {
-                unset($indexes[$index]);
-            }
-        }
-
-        return $indexes;
+        return $this->override['indexes'] ?? parent::getIndexes();
     }
 
     public function shouldUseSyncJobs(): bool

--- a/tests/Fake/IndexConfigurationFake.php
+++ b/tests/Fake/IndexConfigurationFake.php
@@ -2,6 +2,7 @@
 
 namespace SilverStripe\Forager\Tests\Fake;
 
+use ReflectionProperty;
 use SilverStripe\Forager\Interfaces\DocumentInterface;
 use SilverStripe\Forager\Service\IndexConfiguration;
 
@@ -39,7 +40,35 @@ class IndexConfigurationFake extends IndexConfiguration
 
     public function getIndexes(): array
     {
-        return $this->override['indexes'] ?? parent::getIndexes();
+        $indexes = $this->override['indexes'] ?? null;
+
+        if (!$indexes) {
+            return parent::getIndexes();
+        }
+
+        // Convert environment variable defined in YML config to its value
+        array_walk($indexes, function (array &$configuration): void {
+            $configuration = $this->environmentVariableToValue($configuration);
+        });
+
+        // Using reflection because we don't want this property to be part of the public API, but we need access to it
+        // for testing purposes
+        $reflectionProperty = new ReflectionProperty(IndexConfiguration::class, 'onlyIndexes');
+        $reflectionProperty->setAccessible(true);
+
+        $onlyIndexes = $reflectionProperty->getValue($this);
+
+        if (!$onlyIndexes) {
+            return $indexes;
+        }
+
+        foreach (array_keys($indexes) as $index) {
+            if (!in_array($index, $onlyIndexes)) {
+                unset($indexes[$index]);
+            }
+        }
+
+        return $indexes;
     }
 
     public function shouldUseSyncJobs(): bool

--- a/tests/Fake/IndexConfigurationFake.php
+++ b/tests/Fake/IndexConfigurationFake.php
@@ -2,7 +2,6 @@
 
 namespace SilverStripe\Forager\Tests\Fake;
 
-use ReflectionProperty;
 use SilverStripe\Forager\Interfaces\DocumentInterface;
 use SilverStripe\Forager\Service\IndexConfiguration;
 

--- a/tests/Jobs/ClearIndexJobTest.php
+++ b/tests/Jobs/ClearIndexJobTest.php
@@ -21,20 +21,39 @@ class ClearIndexJobTest extends SearchServiceTest
 
     public function testConstruct(): void
     {
-        $config = $this->mockConfig();
+        $this->mockConfig(true);
 
-        // Batch size of 0 is the same as not specifying a batch size, so we should get the batch size from config
-        $job = ClearIndexJob::create('myindex', 0);
-        $this->assertSame($config->getBatchSize(), $job->getBatchSize());
+        // Batch size of 0 is the same as not specifying a batch size, so we should get the lowest batch size defined
+        // in our config for index1
+        $job = ClearIndexJob::create('index1', 0);
+        $this->assertSame(50, $job->getBatchSize());
+
+        // Batch size of 0 is the same as not specifying a batch size, so we should get the lowest batch size defined
+        // in our config for index2
+        $job = ClearIndexJob::create('index2', 0);
+        $this->assertSame(25, $job->getBatchSize());
 
         // Same with not specifying a batch size at all
-        $job = ClearIndexJob::create('myindex');
-        $this->assertSame($config->getBatchSize(), $job->getBatchSize());
+        $job = ClearIndexJob::create('index1');
+        $this->assertSame(50, $job->getBatchSize());
+
+        // Same with not specifying a batch size at all
+        $job = ClearIndexJob::create('index2');
+        $this->assertSame(25, $job->getBatchSize());
+
+        // Check that a batch size is set when explicitly provided
+        $job = ClearIndexJob::create('index1', 33);
+        $this->assertSame(33, $job->getBatchSize());
+    }
+
+    public function testConstructException(): void
+    {
+        $this->mockConfig(true);
 
         // Specifying a batch size under 0 should throw an exception
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('Batch size must be greater than 0');
-        $job = ClearIndexJob::create('myindex', -1);
+        $job = ClearIndexJob::create('index1', -1);
 
         // If no index name is provided, then other config options should not be applied
         $job = ClearIndexJob::create();

--- a/tests/Jobs/IndexJobTest.php
+++ b/tests/Jobs/IndexJobTest.php
@@ -44,4 +44,25 @@ class IndexJobTest extends SearchServiceTest
         $this->assertTrue($job->jobFinished());
     }
 
+    public function testConstruct(): void
+    {
+        $this->mockConfig(true);
+
+        $job = IndexJob::create();
+
+        $this->assertEquals([], $job->getDocuments());
+        $this->assertEquals(Indexer::METHOD_ADD, $job->getMethod());
+        // Should be the lowest define batch_size across our index configuration
+        $this->assertEquals(25, $job->getBatchSize());
+
+        $service = $this->loadIndex(20);
+        $docs = $service->listDocuments('test', 33);
+        $job = IndexJob::create($docs, Indexer::METHOD_DELETE, 33);
+
+        $this->assertEquals($docs, $job->getDocuments());
+        $this->assertEquals(Indexer::METHOD_DELETE, $job->getMethod());
+        // Should be the batch_size that was explicitly set
+        $this->assertEquals(33, $job->getBatchSize());
+    }
+
 }

--- a/tests/Jobs/RemoveDataObjectJobTest.php
+++ b/tests/Jobs/RemoveDataObjectJobTest.php
@@ -111,11 +111,30 @@ class RemoveDataObjectJobTest extends SearchServiceTest
         $this->objFromFixture(DataObjectFake::class, 'one')->delete();
         $this->objFromFixture(DataObjectFake::class, 'three')->delete();
 
-        // This determines whether the document should be added or removed from from the index
+        // This determines whether the document should be added or removed from the index
         foreach ($documents as $document) {
             // The document should be removed from index
             $this->assertFalse($document->shouldIndex());
         }
+    }
+
+    public function testConstruct(): void
+    {
+        $this->mockConfig(true);
+
+        $job = RemoveDataObjectJob::create();
+
+        $this->assertNull($job->getDocument());
+        $this->assertNotNull($job->getTimestamp());
+        // Should be the lowest define batch_size across our index configuration
+        $this->assertEquals(25, $job->getBatchSize());
+
+        $job = RemoveDataObjectJob::create(null, null, 33);
+
+        $this->assertNull($job->getDocument());
+        $this->assertNotNull($job->getTimestamp());
+        // Should be the batch_size that was explicitly set
+        $this->assertEquals(33, $job->getBatchSize());
     }
 
 }

--- a/tests/SearchServiceTest.php
+++ b/tests/SearchServiceTest.php
@@ -21,8 +21,10 @@ abstract class SearchServiceTest extends SapphireTest
     {
         $config = new IndexConfigurationFake();
 
+        Injector::inst()->registerService($config, IndexConfiguration::class);
+
         if ($setConfig) {
-            $config->set(
+            IndexConfiguration::config()->set(
                 'indexes',
                 [
                     'index1' => [
@@ -62,8 +64,7 @@ abstract class SearchServiceTest extends SapphireTest
             );
         }
 
-        Injector::inst()->registerService($config, IndexConfiguration::class);
-        SearchServiceExtension::singleton()->setConfiguration($config);
+        SearchServiceExtension::singleton()->setConfiguration(IndexConfiguration::singleton());
 
         return $config;
     }

--- a/tests/SearchServiceTest.php
+++ b/tests/SearchServiceTest.php
@@ -2,6 +2,7 @@
 
 namespace SilverStripe\Forager\Tests;
 
+use SilverStripe\Control\Controller;
 use SilverStripe\Core\Injector\Injector;
 use SilverStripe\Dev\SapphireTest;
 use SilverStripe\Forager\DataObject\DataObjectDocument;
@@ -11,13 +12,57 @@ use SilverStripe\Forager\Service\IndexConfiguration;
 use SilverStripe\Forager\Tests\Fake\DataObjectFake;
 use SilverStripe\Forager\Tests\Fake\IndexConfigurationFake;
 use SilverStripe\Forager\Tests\Fake\ServiceFake;
+use SilverStripe\Security\Member;
 
 abstract class SearchServiceTest extends SapphireTest
 {
 
-    protected function mockConfig(): IndexConfigurationFake
+    protected function mockConfig(bool $setConfig = false): IndexConfigurationFake
     {
-        Injector::inst()->registerService($config = new IndexConfigurationFake(), IndexConfiguration::class);
+        $config = new IndexConfigurationFake();
+
+        if ($setConfig) {
+            $config->set(
+                'indexes',
+                [
+                    'index1' => [
+                        'includeClasses' => [
+                            DataObjectFake::class => [
+                                'batch_size' => 75,
+                                'fields' => [
+                                    'field1' => true,
+                                    'field2' => true,
+                                ],
+                            ],
+                            Member::class => [
+                                'batch_size' => 50,
+                                'fields' => [
+                                    'field3' => true,
+                                    'field4' => false,
+                                ],
+                            ],
+                        ],
+                    ],
+                    'index2' => [
+                        'includeClasses' => [
+                            DataObjectFake::class => [
+                                'batch_size' => 25,
+                                'fields' => [
+                                    'field5' => true,
+                                ],
+                            ],
+                            Controller::class => [
+                                'fields' => [
+                                    'field6' => true,
+                                ],
+                            ],
+                        ],
+                    ],
+                ]
+            );
+        }
+
+        Injector::inst()->registerService($config, IndexConfiguration::class);
         SearchServiceExtension::singleton()->setConfiguration($config);
 
         return $config;

--- a/tests/Service/IndexConfigurationTest.php
+++ b/tests/Service/IndexConfigurationTest.php
@@ -194,8 +194,7 @@ class IndexConfigurationTest extends SapphireTest
         $this->assertCount(1, $classes);
         $this->assertContains(ViewableData::class, $classes);
 
-        Config::modify()->merge(
-            IndexConfiguration::class,
+        IndexConfiguration::config()->merge(
             'indexes',
             [
                 'index4' => [
@@ -252,8 +251,7 @@ class IndexConfigurationTest extends SapphireTest
         $fields = $config->getFieldsForClass($className);
         $this->assertEmpty($fields);
 
-        Config::modify()->merge(
-            IndexConfiguration::class,
+        IndexConfiguration::config()->merge(
             'indexes',
             [
                 'index5' => [
@@ -411,8 +409,7 @@ class IndexConfigurationTest extends SapphireTest
 
     protected function bootstrapIndexes(): void
     {
-        Config::modify()->set(
-            IndexConfiguration::class,
+        IndexConfiguration::config()->set(
             'indexes',
             [
                 'index1' => [

--- a/tests/Service/IndexConfigurationTest.php
+++ b/tests/Service/IndexConfigurationTest.php
@@ -3,7 +3,6 @@
 namespace SilverStripe\Forager\Tests\Service;
 
 use SilverStripe\Control\Controller;
-use SilverStripe\Core\Config\Config;
 use SilverStripe\Dev\SapphireTest;
 use SilverStripe\Forager\DataObject\DataObjectDocument;
 use SilverStripe\Forager\Schema\Field;

--- a/tests/Tasks/SearchReindexTest.php
+++ b/tests/Tasks/SearchReindexTest.php
@@ -2,51 +2,80 @@
 
 namespace SilverStripe\Forager\Tests\Tasks;
 
+use SilverStripe\Control\Controller;
 use SilverStripe\Control\HTTPRequest;
-use SilverStripe\Core\Injector\Injector;
-use SilverStripe\Forager\Jobs\ReindexJob;
-use SilverStripe\Forager\Service\SyncJobRunner;
+use SilverStripe\Core\Config\Config;
 use SilverStripe\Forager\Tasks\SearchReindex;
+use SilverStripe\Forager\Tests\Fake\DataObjectFake;
 use SilverStripe\Forager\Tests\SearchServiceTest;
+use SilverStripe\Security\Member;
+use Symbiote\QueuedJobs\DataObjects\QueuedJobDescriptor;
+use Symbiote\QueuedJobs\Services\QueuedJobService;
 
 class SearchReindexTest extends SearchServiceTest
 {
 
+    protected $usesDatabase = true; // phpcs:ignore SlevomatCodingStandard.TypeHints
+
     public function testTask(): void
     {
-        $config = $this->mockConfig();
-        $config->set('use_sync_jobs', true);
-        $mock = $this->getMockBuilder(SyncJobRunner::class)
-            ->onlyMethods(['runJob'])
-            ->getMock();
-        $mock->expects($this->once())
-            ->method('runJob')
-            ->with($this->callback(function (ReindexJob $job) {
-                return count($job->getOnlyClasses()) === 1 && $job->getOnlyClasses()[0] === 'foo';
-            }));
-
-        $task = SearchReindex::create();
-        $request = new HTTPRequest('GET', '/', ['onlyClass' => 'foo']);
-
-        Injector::inst()->registerService($mock, SyncJobRunner::class);
-
-        $task->run($request);
-
-        $mock = $this->getMockBuilder(SyncJobRunner::class)
-            ->onlyMethods(['runJob'])
-            ->getMock();
-        $mock->expects($this->once())
-            ->method('runJob')
-            ->with($this->callback(function (ReindexJob $job) {
-                return !$job->getOnlyClasses();
-            }));
+        $this->mockConfig(true);
 
         $task = SearchReindex::create();
         $request = new HTTPRequest('GET', '/', []);
 
-        Injector::inst()->registerService($mock, SyncJobRunner::class);
-
         $task->run($request);
+
+        /** @var QueuedJobDescriptor[] $jobDescriptors */
+        $jobDescriptors = QueuedJobDescriptor::get()->column('SavedJobData');
+
+        // 2 indexes each with 2 defined classes should = 4 jobs
+        $this->assertCount(4, $jobDescriptors);
+
+        $expected = [
+            'index1' => [
+                DataObjectFake::class => 75,
+                Member::class => 50,
+            ],
+            'index2' => [
+                DataObjectFake::class => 25,
+                Controller::class => 100,
+            ],
+        ];
+
+        $result = [];
+
+        // Process our JobDescriptors so that we can make our assertions
+        foreach ($jobDescriptors as $jobDescriptor) {
+            $data = (array) unserialize($jobDescriptor);
+
+            // Each Job should be for a specific index and class
+            $this->assertCount(1, $data['onlyClasses'] ?? []);
+            $this->assertCount(1, $data['onlyIndexes'] ?? []);
+            // We don't know what the batchSize should be for any particular loop, but it shouldn't be null
+            $this->assertNotNull($data['batchSize'] ?? null);
+
+            // Grab the class and index that this job represents
+            $class = array_shift($data['onlyClasses']);
+            $index = array_shift($data['onlyIndexes']);
+
+            // Start building out our expected data structure
+            if (!array_key_exists($index, $result)) {
+                $result[$index] = [];
+            }
+
+            $result[$index][$class] = $data['batchSize'];
+        }
+
+        // Compare our expected data structure with what we were able to build above from our job data
+        $this->assertEquals($expected, $result);
+    }
+
+    protected function setUp(): void
+    {
+        Config::modify()->set(QueuedJobService::class, 'use_shutdown_function', false);
+
+        parent::setUp();
     }
 
 }


### PR DESCRIPTION
## Batch size by class and index

Different classes can require different levels of server resource to process, for example, Files are often more process intensive than (say) Pages.

Provide developers with a way to define a `batch_size` to be used when re-indexing batches of certain classes.

## Unit test changes

I'm sure they were fine before, but they used features I don't really understand - so, some have been updated to use test mechanisms that I understand.