### PR TITLE
Add support for Synonym management

### DIFF
--- a/_config/synonyms.yml
+++ b/_config/synonyms.yml
@@ -1,0 +1,16 @@
+---
+Name: silverstripe-forager-synonyms
+---
+SilverStripe\Core\Injector\Injector:
+  SilverStripe\Forager\Interfaces\Requests\GetSynonymCollectionsAdaptor:
+    class: SilverStripe\Forager\Adaptors\Requests\GetSynonymCollectionsAdaptor
+  SilverStripe\Forager\Interfaces\Requests\GetSynonymRulesAdaptor:
+    class: SilverStripe\Forager\Adaptors\Requests\GetSynonymRulesAdaptor
+  SilverStripe\Forager\Interfaces\Requests\GetSynonymRuleAdaptor:
+    class: SilverStripe\Forager\Adaptors\Requests\GetSynonymRuleAdaptor
+  SilverStripe\Forager\Interfaces\Requests\PostSynonymRuleAdaptor:
+    class: SilverStripe\Forager\Adaptors\Requests\PostSynonymRuleAdaptor
+  SilverStripe\Forager\Interfaces\Requests\PatchSynonymRuleAdaptor:
+    class: SilverStripe\Forager\Adaptors\Requests\PatchSynonymRuleAdaptor
+  SilverStripe\Forager\Interfaces\Requests\DeleteSynonymRuleAdaptor:
+    class: SilverStripe\Forager\Adaptors\Requests\DeleteSynonymRuleAdaptor

--- a/src/Adaptors/Requests/CreateSynonymRuleAdaptor.php
+++ b/src/Adaptors/Requests/CreateSynonymRuleAdaptor.php
@@ -5,11 +5,12 @@ namespace SilverStripe\Forager\Adaptors\Requests;
 use BadMethodCallException;
 use SilverStripe\Forager\Interfaces\Requests\CreateSynonymRuleAdaptor as PostSynonymRuleAdaptorInterface;
 use SilverStripe\Forager\Service\Query\SynonymRule;
+use SilverStripe\Forager\Service\Results\SynonymRule as SynonymRuleResult;
 
 class CreateSynonymRuleAdaptor implements PostSynonymRuleAdaptorInterface
 {
 
-    public function process(int|string $synonymCollectionId, SynonymRule $synonymRule): string|int
+    public function process(int|string $synonymCollectionId, SynonymRule $synonymRule): SynonymRuleResult
     {
         throw new BadMethodCallException('PostSynonymRuleAdaptor has not been implemented');
     }

--- a/src/Adaptors/Requests/CreateSynonymRuleAdaptor.php
+++ b/src/Adaptors/Requests/CreateSynonymRuleAdaptor.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace SilverStripe\Forager\Adaptors\Requests;
+
+use BadMethodCallException;
+use SilverStripe\Forager\Interfaces\Requests\CreateSynonymRuleAdaptor as PostSynonymRuleAdaptorInterface;
+use SilverStripe\Forager\Service\Query\SynonymRule;
+
+class CreateSynonymRuleAdaptor implements PostSynonymRuleAdaptorInterface
+{
+
+    public function process(int|string $synonymCollectionId, SynonymRule $synonymRule): string|int
+    {
+        throw new BadMethodCallException('PostSynonymRuleAdaptor has not been implemented');
+    }
+
+}

--- a/src/Adaptors/Requests/DeleteSynonymRuleAdaptor.php
+++ b/src/Adaptors/Requests/DeleteSynonymRuleAdaptor.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace SilverStripe\Forager\Adaptors\Requests;
+
+use BadMethodCallException;
+use SilverStripe\Forager\Interfaces\Requests\DeleteSynonymRuleAdaptor as DeleteSynonymRuleAdaptorInterface;
+
+class DeleteSynonymRuleAdaptor implements DeleteSynonymRuleAdaptorInterface
+{
+
+    public function process(int|string $synonymCollectionId, int|string $synonymRuleId): bool
+    {
+        throw new BadMethodCallException('DeleteSynonymRuleAdaptor has not been implemented');
+    }
+
+}

--- a/src/Adaptors/Requests/GetSynonymCollectionsAdaptor.php
+++ b/src/Adaptors/Requests/GetSynonymCollectionsAdaptor.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace SilverStripe\Forager\Adaptors\Requests;
+
+use BadMethodCallException;
+use SilverStripe\Forager\Interfaces\Requests\GetSynonymCollectionsAdaptor as GetSynonymCollectionsAdaptorInterface;
+use SilverStripe\Forager\Service\Results\SynonymCollections;
+
+class GetSynonymCollectionsAdaptor implements GetSynonymCollectionsAdaptorInterface
+{
+
+    public function process(): SynonymCollections
+    {
+        throw new BadMethodCallException('GetSynonymCollectionsAdaptor has not been implemented');
+    }
+
+}

--- a/src/Adaptors/Requests/GetSynonymRuleAdaptor.php
+++ b/src/Adaptors/Requests/GetSynonymRuleAdaptor.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace SilverStripe\Forager\Adaptors\Requests;
+
+use BadMethodCallException;
+use SilverStripe\Forager\Interfaces\Requests\GetSynonymRuleAdaptor as GetSynonymRuleAdaptorInterface;
+use SilverStripe\Forager\Service\Results\SynonymRule;
+
+class GetSynonymRuleAdaptor implements GetSynonymRuleAdaptorInterface
+{
+
+    public function process(int|string $synonymCollectionId, int|string $synonymRuleId): SynonymRule
+    {
+        throw new BadMethodCallException('GetSynonymRuleAdaptor has not been implemented');
+    }
+
+}

--- a/src/Adaptors/Requests/GetSynonymRulesAdaptor.php
+++ b/src/Adaptors/Requests/GetSynonymRulesAdaptor.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace SilverStripe\Forager\Adaptors\Requests;
+
+use BadMethodCallException;
+use SilverStripe\Forager\Interfaces\Requests\GetSynonymRulesAdaptor as GetSynonymRulesAdaptorInterface;
+use SilverStripe\Forager\Service\Results\SynonymRules;
+
+class GetSynonymRulesAdaptor implements GetSynonymRulesAdaptorInterface
+{
+
+    public function process(int|string $synonymCollectionId): SynonymRules
+    {
+        throw new BadMethodCallException('GetSynonymRulesAdaptor has not been implemented');
+    }
+
+}

--- a/src/Adaptors/Requests/UpdateSynonymRuleAdaptor.php
+++ b/src/Adaptors/Requests/UpdateSynonymRuleAdaptor.php
@@ -5,6 +5,7 @@ namespace SilverStripe\Forager\Adaptors\Requests;
 use BadMethodCallException;
 use SilverStripe\Forager\Interfaces\Requests\UpdateSynonymRuleAdaptor as PatchSynonymRuleAdaptorInterface;
 use SilverStripe\Forager\Service\Query\SynonymRule;
+use SilverStripe\Forager\Service\Results\SynonymRule as SynonymRuleResult;
 
 class UpdateSynonymRuleAdaptor implements PatchSynonymRuleAdaptorInterface
 {
@@ -13,7 +14,7 @@ class UpdateSynonymRuleAdaptor implements PatchSynonymRuleAdaptorInterface
         int|string $synonymCollectionId,
         int|string $synonymRuleId,
         SynonymRule $synonymRule
-    ): string|int {
+    ): SynonymRuleResult {
         throw new BadMethodCallException('PatchSynonymRuleAdaptor has not been implemented');
     }
 

--- a/src/Adaptors/Requests/UpdateSynonymRuleAdaptor.php
+++ b/src/Adaptors/Requests/UpdateSynonymRuleAdaptor.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace SilverStripe\Forager\Adaptors\Requests;
+
+use BadMethodCallException;
+use SilverStripe\Forager\Interfaces\Requests\UpdateSynonymRuleAdaptor as PatchSynonymRuleAdaptorInterface;
+use SilverStripe\Forager\Service\Query\SynonymRule;
+
+class UpdateSynonymRuleAdaptor implements PatchSynonymRuleAdaptorInterface
+{
+
+    public function process(
+        int|string $synonymCollectionId,
+        int|string $synonymRuleId,
+        SynonymRule $synonymRule
+    ): string|int {
+        throw new BadMethodCallException('PatchSynonymRuleAdaptor has not been implemented');
+    }
+
+}

--- a/src/Admin/SearchAdmin.php
+++ b/src/Admin/SearchAdmin.php
@@ -179,7 +179,15 @@ class SearchAdmin extends LeftAndMain implements PermissionProvider
             ->setReadonly(true)
             ->setRightTitle('i.e. status is one of: ' . implode(', ', $stoppedStatuses));
 
-        return $form->setFields(FieldList::create($fields));
+        $fieldList = FieldList::create($fields);
+
+        $this->extend('updateEditFormFieldList', $fieldList);
+
+        $form->setFields($fieldList);
+
+        $this->extend('updateEditForm', $form);
+
+        return $form;
     }
 
     /**

--- a/src/Interfaces/Requests/CreateSynonymRuleAdaptor.php
+++ b/src/Interfaces/Requests/CreateSynonymRuleAdaptor.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace SilverStripe\Forager\Interfaces\Requests;
+
+use SilverStripe\Forager\Service\Query\SynonymRule;
+
+interface CreateSynonymRuleAdaptor
+{
+
+    /**
+     * @return string|int the ID of the synonym rule that was created
+     */
+    public function process(string|int $synonymCollectionId, SynonymRule $synonymRule): string|int;
+
+}

--- a/src/Interfaces/Requests/CreateSynonymRuleAdaptor.php
+++ b/src/Interfaces/Requests/CreateSynonymRuleAdaptor.php
@@ -3,13 +3,11 @@
 namespace SilverStripe\Forager\Interfaces\Requests;
 
 use SilverStripe\Forager\Service\Query\SynonymRule;
+use SilverStripe\Forager\Service\Results\SynonymRule as SynonymRuleResult;
 
 interface CreateSynonymRuleAdaptor
 {
 
-    /**
-     * @return string|int the ID of the synonym rule that was created
-     */
-    public function process(string|int $synonymCollectionId, SynonymRule $synonymRule): string|int;
+    public function process(string|int $synonymCollectionId, SynonymRule $synonymRule): SynonymRuleResult;
 
 }

--- a/src/Interfaces/Requests/DeleteSynonymRuleAdaptor.php
+++ b/src/Interfaces/Requests/DeleteSynonymRuleAdaptor.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace SilverStripe\Forager\Interfaces\Requests;
+
+interface DeleteSynonymRuleAdaptor
+{
+
+    /**
+     * @return bool success or failure to delete the synonym rule
+     */
+    public function process(string|int $synonymCollectionId, string|int $synonymRuleId): bool;
+
+}

--- a/src/Interfaces/Requests/GetSynonymCollectionsAdaptor.php
+++ b/src/Interfaces/Requests/GetSynonymCollectionsAdaptor.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace SilverStripe\Forager\Interfaces\Requests;
+
+use SilverStripe\Forager\Service\Results\SynonymCollections;
+
+interface GetSynonymCollectionsAdaptor
+{
+
+    public function process(): SynonymCollections;
+
+}

--- a/src/Interfaces/Requests/GetSynonymRuleAdaptor.php
+++ b/src/Interfaces/Requests/GetSynonymRuleAdaptor.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace SilverStripe\Forager\Interfaces\Requests;
+
+use SilverStripe\Forager\Service\Results\SynonymRule;
+
+interface GetSynonymRuleAdaptor
+{
+
+    public function process(string|int $synonymCollectionId, string|int $synonymRuleId): SynonymRule;
+
+}

--- a/src/Interfaces/Requests/GetSynonymRulesAdaptor.php
+++ b/src/Interfaces/Requests/GetSynonymRulesAdaptor.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace SilverStripe\Forager\Interfaces\Requests;
+
+use SilverStripe\Forager\Service\Results\SynonymRules;
+
+interface GetSynonymRulesAdaptor
+{
+
+    public function process(string|int $synonymCollectionId): SynonymRules;
+
+}

--- a/src/Interfaces/Requests/UpdateSynonymRuleAdaptor.php
+++ b/src/Interfaces/Requests/UpdateSynonymRuleAdaptor.php
@@ -3,17 +3,15 @@
 namespace SilverStripe\Forager\Interfaces\Requests;
 
 use SilverStripe\Forager\Service\Query\SynonymRule;
+use SilverStripe\Forager\Service\Results\SynonymRule as SynonymRuleResult;
 
 interface UpdateSynonymRuleAdaptor
 {
 
-    /**
-     * @return string|int the ID of the synonym rule that was updated
-     */
     public function process(
         string|int $synonymCollectionId,
         string|int $synonymRuleId,
         SynonymRule $synonymRule
-    ): string|int;
+    ): SynonymRuleResult;
 
 }

--- a/src/Interfaces/Requests/UpdateSynonymRuleAdaptor.php
+++ b/src/Interfaces/Requests/UpdateSynonymRuleAdaptor.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace SilverStripe\Forager\Interfaces\Requests;
+
+use SilverStripe\Forager\Service\Query\SynonymRule;
+
+interface UpdateSynonymRuleAdaptor
+{
+
+    /**
+     * @return string|int the ID of the synonym rule that was updated
+     */
+    public function process(
+        string|int $synonymCollectionId,
+        string|int $synonymRuleId,
+        SynonymRule $synonymRule
+    ): string|int;
+
+}

--- a/src/Service/Query/SynonymRule.php
+++ b/src/Service/Query/SynonymRule.php
@@ -1,0 +1,81 @@
+<?php
+
+namespace SilverStripe\Forager\Service\Query;
+
+use SilverStripe\Core\Injector\Injectable;
+
+class SynonymRule
+{
+
+    use Injectable;
+
+    /**
+     * @see SynonymRule::$root docblock for an explanation
+     * @var string[]
+     */
+    private array $root = [];
+
+    /**
+     * @var string[]
+     */
+    private array $synonyms = [];
+
+    /**
+     * @see SynonymRule::$type docblock for an explanation of $type
+     */
+    public function __construct(private readonly string $type)
+    {
+    }
+
+    public function getType(): ?string
+    {
+        return $this->type;
+    }
+
+    public function getRoot(): array
+    {
+        return $this->root;
+    }
+
+    public function addRoot(string $value): static
+    {
+        $this->root[] = $value;
+
+        return $this;
+    }
+
+    public function setRoot(array $values): static
+    {
+        # Performing a loop on the array instead of direct assignment effectively checks that all values are of the
+        # type/s expected by addRoot()
+        foreach ($values as $value) {
+            $this->addRoot($value);
+        }
+
+        return $this;
+    }
+
+    public function getSynonyms(): array
+    {
+        return $this->synonyms;
+    }
+
+    public function addSynonym(string $value): static
+    {
+        $this->synonyms[] = $value;
+
+        return $this;
+    }
+
+    public function setSynonyms(array $values): static
+    {
+        # Performing a loop on the array instead of direct assignment effectively checks that all values are of the
+        # type/s expected by addSynonym()
+        foreach ($values as $value) {
+            $this->addSynonym($value);
+        }
+
+        return $this;
+    }
+
+}

--- a/src/Service/Results/SynonymCollection.php
+++ b/src/Service/Results/SynonymCollection.php
@@ -2,10 +2,11 @@
 
 namespace SilverStripe\Forager\Service\Results;
 
+use JsonSerializable;
 use SilverStripe\Core\Injector\Injectable;
 use SilverStripe\View\ViewableData;
 
-class SynonymCollection extends ViewableData
+class SynonymCollection extends ViewableData implements JsonSerializable
 {
 
     use Injectable;
@@ -18,6 +19,13 @@ class SynonymCollection extends ViewableData
     public function getID(): int|string
     {
         return $this->id;
+    }
+
+    public function jsonSerialize(): mixed
+    {
+        return [
+            'id' => $this->id,
+        ];
     }
 
 }

--- a/src/Service/Results/SynonymCollection.php
+++ b/src/Service/Results/SynonymCollection.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace SilverStripe\Forager\Service\Results;
+
+use SilverStripe\Core\Injector\Injectable;
+use SilverStripe\View\ViewableData;
+
+class SynonymCollection extends ViewableData
+{
+
+    use Injectable;
+
+    public function __construct(private readonly string|int $id)
+    {
+        parent::__construct();
+    }
+
+    public function getID(): int|string
+    {
+        return $this->id;
+    }
+
+}

--- a/src/Service/Results/SynonymCollection.php
+++ b/src/Service/Results/SynonymCollection.php
@@ -16,7 +16,7 @@ class SynonymCollection extends ViewableData implements JsonSerializable
         parent::__construct();
     }
 
-    public function getID(): int|string
+    public function getId(): int|string
     {
         return $this->id;
     }

--- a/src/Service/Results/SynonymCollections.php
+++ b/src/Service/Results/SynonymCollections.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace SilverStripe\Forager\Service\Results;
+
+use InvalidArgumentException;
+use SilverStripe\ORM\ArrayList;
+
+class SynonymCollections extends ArrayList
+{
+
+    /**
+     * @var string
+     * @phpcsSuppress SlevomatCodingStandard.TypeHints.PropertyTypeHint.MissingNativeTypeHint
+     */
+    protected $dataClass = SynonymCollection::class;
+
+    /**
+     * @param SynonymCollection $item
+     * @return void
+     * @phpcsSuppress SlevomatCodingStandard.TypeHints.ParameterTypeHint.MissingNativeTypeHint
+     * @phpcsSuppress SlevomatCodingStandard.TypeHints.ReturnTypeHint.MissingNativeTypeHint
+     */
+    public function push($item)
+    {
+        if (!$item instanceof SynonymCollection) {
+            throw new InvalidArgumentException('Item must be an instance of SynonymCollection');
+        }
+
+        parent::push($item);
+    }
+
+}

--- a/src/Service/Results/SynonymCollections.php
+++ b/src/Service/Results/SynonymCollections.php
@@ -3,9 +3,10 @@
 namespace SilverStripe\Forager\Service\Results;
 
 use InvalidArgumentException;
+use JsonSerializable;
 use SilverStripe\ORM\ArrayList;
 
-class SynonymCollections extends ArrayList
+class SynonymCollections extends ArrayList implements JsonSerializable
 {
 
     /**
@@ -27,6 +28,11 @@ class SynonymCollections extends ArrayList
         }
 
         parent::push($item);
+    }
+
+    public function jsonSerialize(): mixed
+    {
+        return $this->toArray();
     }
 
 }

--- a/src/Service/Results/SynonymRule.php
+++ b/src/Service/Results/SynonymRule.php
@@ -56,7 +56,7 @@ class SynonymRule extends ViewableData implements JsonSerializable
         parent::__construct();
     }
 
-    public function getID(): int|string|null
+    public function getId(): int|string|null
     {
         return $this->id;
     }
@@ -95,6 +95,9 @@ class SynonymRule extends ViewableData implements JsonSerializable
 
     public function setRoot(array $values): static
     {
+        // Reset any existing values
+        $this->root = [];
+
         # Performing a loop on the array instead of direct assignment effectively checks that all values are of the
         # type/s expected by addRoot()
         foreach ($values as $value) {
@@ -126,6 +129,9 @@ class SynonymRule extends ViewableData implements JsonSerializable
 
     public function setSynonyms(array $values): static
     {
+        // Reset any existing values
+        $this->synonyms = [];
+
         # Performing a loop on the array instead of direct assignment effectively checks that all values are of the
         # type/s expected by addSynonym()
         foreach ($values as $value) {
@@ -138,7 +144,7 @@ class SynonymRule extends ViewableData implements JsonSerializable
     public function jsonSerialize(): mixed
     {
         return [
-            'id' => $this->getID(),
+            'id' => $this->getId(),
             'type' => $this->getType(),
             'root' => $this->getRoot(),
             'synonyms' => $this->getSynonyms(),

--- a/src/Service/Results/SynonymRule.php
+++ b/src/Service/Results/SynonymRule.php
@@ -2,10 +2,11 @@
 
 namespace SilverStripe\Forager\Service\Results;
 
+use JsonSerializable;
 use SilverStripe\Core\Injector\Injectable;
 use SilverStripe\View\ViewableData;
 
-class SynonymRule extends ViewableData
+class SynonymRule extends ViewableData implements JsonSerializable
 {
 
     use Injectable;
@@ -132,6 +133,16 @@ class SynonymRule extends ViewableData
         }
 
         return $this;
+    }
+
+    public function jsonSerialize(): mixed
+    {
+        return [
+            'id' => $this->getID(),
+            'type' => $this->getType(),
+            'root' => $this->getRoot(),
+            'synonyms' => $this->getSynonyms(),
+        ];
     }
 
 }

--- a/src/Service/Results/SynonymRule.php
+++ b/src/Service/Results/SynonymRule.php
@@ -1,0 +1,137 @@
+<?php
+
+namespace SilverStripe\Forager\Service\Results;
+
+use SilverStripe\Core\Injector\Injectable;
+use SilverStripe\View\ViewableData;
+
+class SynonymRule extends ViewableData
+{
+
+    use Injectable;
+
+    public const TYPE_EQUIVALENT = 'TYPE_EQUIVALENT';
+    public const TYPE_DIRECTIONAL = 'TYPE_DIRECTIONAL';
+
+    /**
+     * Different services have different names for their synonym types
+     *
+     * Elasticsearch:
+     *  * TYPE_EQUIVALENT = Equivalent synonyms
+     *  * TYPE_DIRECTIONAL = Explicit synonyms
+     *
+     * Algolia:
+     * * TYPE_EQUIVALENT = Regular synonyms
+     * * TYPE_DIRECTIONAL = One-way synonyms
+     *
+     * Typesense:
+     * * TYPE_EQUIVALENT = Multi-way synonyms
+     * * TYPE_DIRECTIONAL = One-way synonyms
+     */
+    private ?string $type = null;
+
+    /**
+     * Used for "directional" synonyms
+     *
+     * Different services call this value (or values) different things
+     *
+     * * Elasticsearch: "Left hand side" of the arrow ("=>") declaration
+     * * Algolia: Input
+     * * Typesense: Root
+     *
+     * All have the same result though. This value (or values) will be transformed into your synonym values
+     *
+     * @var string[]
+     */
+    private array $root = [];
+
+    /**
+     * @var string[]
+     */
+    private array $synonyms = [];
+
+    public function __construct(private readonly string|int $id)
+    {
+        parent::__construct();
+    }
+
+    public function getID(): int|string|null
+    {
+        return $this->id;
+    }
+
+    public function getType(): ?string
+    {
+        return $this->type;
+    }
+
+    public function setType(?string $type): static
+    {
+        $this->type = $type;
+
+        return $this;
+    }
+
+    public function getRoot(): array
+    {
+        return $this->root;
+    }
+
+    /**
+     * Useful method to use if you want to display this data in (for example) a GridField
+     */
+    public function getRootAsString(): string
+    {
+        return implode(', ', $this->root);
+    }
+
+    public function addRoot(string $value): static
+    {
+        $this->root[] = $value;
+
+        return $this;
+    }
+
+    public function setRoot(array $values): static
+    {
+        # Performing a loop on the array instead of direct assignment effectively checks that all values are of the
+        # type/s expected by addRoot()
+        foreach ($values as $value) {
+            $this->addRoot($value);
+        }
+
+        return $this;
+    }
+
+    public function getSynonyms(): array
+    {
+        return $this->synonyms;
+    }
+
+    /**
+     * Useful method to use if you want to display this data in (for example) a GridField
+     */
+    public function getSynonymsAsString(): string
+    {
+        return implode(', ', $this->synonyms);
+    }
+
+    public function addSynonym(string $value): static
+    {
+        $this->synonyms[] = $value;
+
+        return $this;
+    }
+
+    public function setSynonyms(array $values): static
+    {
+        # Performing a loop on the array instead of direct assignment effectively checks that all values are of the
+        # type/s expected by addSynonym()
+        foreach ($values as $value) {
+            $this->addSynonym($value);
+        }
+
+        return $this;
+    }
+
+}

--- a/src/Service/Results/SynonymRules.php
+++ b/src/Service/Results/SynonymRules.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace SilverStripe\Forager\Service\Results;
+
+use InvalidArgumentException;
+use SilverStripe\ORM\ArrayList;
+
+class SynonymRules extends ArrayList
+{
+
+    /**
+     * @var string
+     * @phpcsSuppress SlevomatCodingStandard.TypeHints.PropertyTypeHint.MissingNativeTypeHint
+     */
+    protected $dataClass = SynonymRule::class;
+
+    /**
+     * @param SynonymRule $item
+     * @return void
+     * @phpcsSuppress SlevomatCodingStandard.TypeHints.ParameterTypeHint.MissingNativeTypeHint
+     * @phpcsSuppress SlevomatCodingStandard.TypeHints.ReturnTypeHint.MissingNativeTypeHint
+     */
+    public function push($item)
+    {
+        if (!$item instanceof SynonymRule) {
+            throw new InvalidArgumentException('Item must be an instance of SynonymRule');
+        }
+
+        parent::push($item);
+    }
+
+}

--- a/src/Service/Results/SynonymRules.php
+++ b/src/Service/Results/SynonymRules.php
@@ -3,9 +3,10 @@
 namespace SilverStripe\Forager\Service\Results;
 
 use InvalidArgumentException;
+use JsonSerializable;
 use SilverStripe\ORM\ArrayList;
 
-class SynonymRules extends ArrayList
+class SynonymRules extends ArrayList implements JsonSerializable
 {
 
     /**
@@ -27,6 +28,11 @@ class SynonymRules extends ArrayList
         }
 
         parent::push($item);
+    }
+
+    public function jsonSerialize(): mixed
+    {
+        return $this->toArray();
     }
 
 }

--- a/src/Service/SynonymService.php
+++ b/src/Service/SynonymService.php
@@ -1,0 +1,115 @@
+<?php
+
+namespace SilverStripe\Forager\Service;
+
+use SilverStripe\Core\Injector\Injectable;
+use SilverStripe\Forager\Interfaces\Requests\CreateSynonymRuleAdaptor;
+use SilverStripe\Forager\Interfaces\Requests\DeleteSynonymRuleAdaptor;
+use SilverStripe\Forager\Interfaces\Requests\GetSynonymCollectionsAdaptor;
+use SilverStripe\Forager\Interfaces\Requests\GetSynonymRuleAdaptor;
+use SilverStripe\Forager\Interfaces\Requests\GetSynonymRulesAdaptor;
+use SilverStripe\Forager\Interfaces\Requests\UpdateSynonymRuleAdaptor;
+use SilverStripe\Forager\Service\Query\SynonymRule as SynonymRuleQuery;
+use SilverStripe\Forager\Service\Results\SynonymCollections;
+use SilverStripe\Forager\Service\Results\SynonymRule as SynonymRuleResult;
+use SilverStripe\Forager\Service\Results\SynonymRules;
+
+class SynonymService
+{
+
+    use Injectable;
+
+    private ?GetSynonymCollectionsAdaptor $getSynonymCollectionsAdaptor = null;
+
+    private ?GetSynonymRulesAdaptor $getSynonymRulesAdaptor = null;
+
+    private ?GetSynonymRuleAdaptor $getSynonymRuleAdaptor = null;
+
+    private ?CreateSynonymRuleAdaptor $createSynonymRuleAdaptor = null;
+
+    private ?UpdateSynonymRuleAdaptor $updateSynonymRuleAdaptor = null;
+
+    private ?DeleteSynonymRuleAdaptor $deleteSynonymRuleAdaptor = null;
+
+    private static array $dependencies = [
+        'getSynonymCollectionsAdaptor' => '%$' . GetSynonymCollectionsAdaptor::class,
+        'getSynonymRulesAdaptor' => '%$' . GetSynonymRulesAdaptor::class,
+        'getSynonymRuleAdaptor' => '%$' . GetSynonymRuleAdaptor::class,
+        'createSynonymRuleAdaptor' => '%$' . CreateSynonymRuleAdaptor::class,
+        'updateSynonymRuleAdaptor' => '%$' . UpdateSynonymRuleAdaptor::class,
+        'deleteSynonymRuleAdaptor' => '%$' . DeleteSynonymRuleAdaptor::class,
+    ];
+
+    public function setGetSynonymCollectionsAdaptor(?GetSynonymCollectionsAdaptor $getSynonymCollectionsAdaptor): void
+    {
+        $this->getSynonymCollectionsAdaptor = $getSynonymCollectionsAdaptor;
+    }
+
+    public function setGetSynonymRulesAdaptor(?GetSynonymRulesAdaptor $getSynonymRulesAdaptor): void
+    {
+        $this->getSynonymRulesAdaptor = $getSynonymRulesAdaptor;
+    }
+
+    public function setGetSynonymRuleAdaptor(?GetSynonymRuleAdaptor $getSynonymRuleAdaptor): void
+    {
+        $this->getSynonymRuleAdaptor = $getSynonymRuleAdaptor;
+    }
+
+    public function setCreateSynonymRuleAdaptor(?CreateSynonymRuleAdaptor $createSynonymRuleAdaptor): void
+    {
+        $this->createSynonymRuleAdaptor = $createSynonymRuleAdaptor;
+    }
+
+    public function setUpdateSynonymRuleAdaptor(?UpdateSynonymRuleAdaptor $updateSynonymRuleAdaptor): void
+    {
+        $this->updateSynonymRuleAdaptor = $updateSynonymRuleAdaptor;
+    }
+
+    public function setDeleteSynonymRuleAdaptor(?DeleteSynonymRuleAdaptor $deleteSynonymRuleAdaptor): void
+    {
+        $this->deleteSynonymRuleAdaptor = $deleteSynonymRuleAdaptor;
+    }
+
+    public function getSynonymCollections(): SynonymCollections
+    {
+        return $this->getSynonymCollectionsAdaptor->process();
+    }
+
+    public function getSynonymRules(string|int $synonymCollectionId): SynonymRules
+    {
+        return $this->getSynonymRulesAdaptor->process($synonymCollectionId);
+    }
+
+    public function getSynonymRule(string|int $synonymCollectionId, string|int $synonymRuleId): SynonymRuleResult
+    {
+        return $this->getSynonymRuleAdaptor->process($synonymCollectionId, $synonymRuleId);
+    }
+
+    /**
+     * @return string|int the ID of the synonym rule that was created
+     */
+    public function createSynonymRule(string|int $synonymCollectionId, SynonymRuleQuery $synonymRule): string|int
+    {
+        return $this->createSynonymRuleAdaptor->process($synonymCollectionId, $synonymRule);
+    }
+
+    /**
+     * @return string|int the ID of the synonym rule that was updated
+     */
+    public function updateSynonymRule(
+        string|int $synonymCollectionId,
+        string|int $synonymRuleId,
+        SynonymRuleQuery $synonymRule
+    ): string|int {
+        return $this->updateSynonymRuleAdaptor->process($synonymCollectionId, $synonymRuleId, $synonymRule);
+    }
+
+    /**
+     * @return bool success or failure to delete the synonym rule
+     */
+    public function deleteSynonymRule(string|int $synonymCollectionId, string|int $synonymRuleId): bool
+    {
+        return $this->deleteSynonymRuleAdaptor->process($synonymCollectionId, $synonymRuleId);
+    }
+
+}

--- a/tests/Service/Results/SynonymsCollectionsTest.php
+++ b/tests/Service/Results/SynonymsCollectionsTest.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace SilverStripe\Forager\Tests\Service\Results;
+
+use SilverStripe\Dev\SapphireTest;
+use SilverStripe\Forager\Service\Results\SynonymCollection;
+use SilverStripe\Forager\Service\Results\SynonymCollections;
+
+class SynonymsCollectionsTest extends SapphireTest
+{
+
+    public function testJsonSerializable(): void
+    {
+        $synonymCollections = SynonymCollections::create();
+        $synonymCollections->add(SynonymCollection::create('id1'));
+        $synonymCollections->add(SynonymCollection::create('id2'));
+
+        $expected = [
+            [
+                'id' => 'id1',
+            ],
+            [
+                'id' => 'id2',
+            ],
+        ];
+        $expected = json_encode($expected);
+
+        $this->assertEquals($expected, json_encode($synonymCollections));
+
+        $synonymCollections = SynonymCollections::create();
+
+        $this->assertEquals(json_encode([]), json_encode($synonymCollections));
+    }
+
+}

--- a/tests/Service/Results/SynonymsRulesTest.php
+++ b/tests/Service/Results/SynonymsRulesTest.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace SilverStripe\Forager\Tests\Service\Results;
+
+use SilverStripe\Dev\SapphireTest;
+use SilverStripe\Forager\Service\Results\SynonymRule;
+use SilverStripe\Forager\Service\Results\SynonymRules;
+
+class SynonymsRulesTest extends SapphireTest
+{
+
+    public function testJsonSerializable(): void
+    {
+        $synonymRules = SynonymRules::create();
+
+        $synonymRuleOne = SynonymRule::create('id1');
+        $synonymRuleOne->setType(SynonymRule::TYPE_DIRECTIONAL);
+        $synonymRuleOne->setRoot(['yo', 'sup']);
+        $synonymRuleOne->setSynonyms(['hi', 'hello']);
+
+        $synonymRuleTwo = SynonymRule::create('id2');
+        $synonymRuleTwo->setType(SynonymRule::TYPE_EQUIVALENT);
+        $synonymRuleTwo->setSynonyms(['hi', 'hello']);
+
+        $synonymRuleThree = SynonymRule::create('id3');
+        $synonymRuleThree->setType(SynonymRule::TYPE_EQUIVALENT);
+
+        $synonymRules->add($synonymRuleOne);
+        $synonymRules->add($synonymRuleTwo);
+        $synonymRules->add($synonymRuleThree);
+
+        $expected = [
+            [
+                'id' => 'id1',
+                'type' => SynonymRule::TYPE_DIRECTIONAL,
+                'root' => ['yo', 'sup'],
+                'synonyms' => ['hi', 'hello'],
+            ],
+            [
+                'id' => 'id2',
+                'type' => SynonymRule::TYPE_EQUIVALENT,
+                'root' => [],
+                'synonyms' => ['hi', 'hello'],
+            ],
+            [
+                'id' => 'id3',
+                'type' => SynonymRule::TYPE_EQUIVALENT,
+                'root' => [],
+                'synonyms' => [],
+            ],
+        ];
+        $expected = json_encode($expected);
+
+        $this->assertEquals($expected, json_encode($synonymRules));
+
+        $synonymRules = SynonymRules::create();
+
+        $this->assertEquals(json_encode([]), json_encode($synonymRules));
+    }
+
+}


### PR DESCRIPTION
## Service

This follows the same paradigm as the Discoverer module, and allows us to add new request methods to the service in the future without causing any breaking changes.

Plugin modules can then choose which service methods they would like to provide adaptors for.

## Management UI

We're not including a management interface in these changes (perhaps we will later?), but I just wanted to quickly see that it was possible to do something like this with a `GridField`. This is using the Elastic Enterprise Search plugin.

![Screenshot 2025-05-01 at 8 39 35 AM](https://github.com/user-attachments/assets/0e508777-88f2-4744-b1bd-ed52bb84303e)
![Screenshot 2025-05-01 at 8 39 20 AM](https://github.com/user-attachments/assets/683de2cf-1f00-42e4-beda-78948f49c032)
