### PR TITLE
Allow complete control of shouldIndex logic by DataObjects

### DIFF
--- a/docs/en/customising_more.md
+++ b/docs/en/customising_more.md
@@ -53,28 +53,35 @@ customise your results.
 This method can be added to multiple extensions.
 
 When an extension to `DataObjectDocument` can add this method to arbitrarily update all
- DataObject documents before they are handed off to the indexer. This method is called after the `DocumentBuilder` has applied its own metadata.
- 
- When an extension to a DataObject has this method, it is used to update the document for
- just that record.
- 
- ### canIndexInSearch(): bool
- 
- A DataObject extension implementing this method can supply custom logic for determining
- if the record should be indexed.
- 
- ### onBeforeAttributesFromObject(): void
- 
- A DataObject extension implementing this method can carry out any side effects that should
- happen as a result of a DataObject being ready to go into the index. It is invoked before
- `DocumentBuilder` has processed the document.
- 
- ### updateSearchDependentDocuments(&$dependentDocs): void
- 
- A DataObject extension implementing this method can add dependent documents to the given list.
- This is particularly relevant if you're not using `auto_dependency_tracking`. It is important 
- to remember that `$dependentDocs` in this context should be first-class `DocumentInterface`
- instances, not DataObjects.
+DataObject documents before they are handed off to the indexer. This method is called after the `DocumentBuilder` has applied its own metadata.
+
+When an extension to a DataObject has this method, it is used to update the document for
+just that record.
+
+### canIndexInSearch(): bool
+
+A DataObject extension implementing this method can supply custom logic for determining
+if the record should be indexed.
+
+### shouldIndex(): bool
+
+A DataObject extension implementing this method _completely_ overrides the default logic
+for determining if the record should be indexed. This should be used with caution, as it
+foregoes standard checks regarding the record's visibility, publication status, etc. In
+most cases, you should use `canIndexInSearch()` instead.
+
+### onBeforeAttributesFromObject(): void
+
+A DataObject extension implementing this method can carry out any side effects that should
+happen as a result of a DataObject being ready to go into the index. It is invoked before
+`DocumentBuilder` has processed the document.
+
+### updateSearchDependentDocuments(&$dependentDocs): void
+
+A DataObject extension implementing this method can add dependent documents to the given list.
+This is particularly relevant if you're not using `auto_dependency_tracking`. It is important 
+to remember that `$dependentDocs` in this context should be first-class `DocumentInterface`
+instances, not DataObjects.
  
 ## More information
 

--- a/src/DataObject/DataObjectDocument.php
+++ b/src/DataObject/DataObjectDocument.php
@@ -123,6 +123,14 @@ class DataObjectDocument implements
     {
         $dataObject = $this->getDataObject();
 
+        // Allow DataObjects to completely override the indexing decision if necessary
+        if ($dataObject->hasMethod('shouldIndex')) {
+            $result = $dataObject->shouldIndex();
+            if (is_bool($result)) {
+                return $result;
+            }
+        }
+
         // If an anonymous user can't view it
         $isPublic = Member::actAs(null, static function () use ($dataObject) {
             // Need to make sure that the version of the DataObject that we access is always the LIVE version


### PR DESCRIPTION
The current extension point in the `shouldIndex()` method only triggers after all default logic has been exhausted, limiting the ability of DataObjects to define their own rules for indexing - for example, to allow private content to enter the index.

This change allows `DataObject`s / extensions to directly replace the logic of `shouldIndex()`, and adds documentation warning of the implications of ignoring the default logic.