### PR TITLE
Move db build configure to extension

### DIFF
--- a/_config/extensions.yml
+++ b/_config/extensions.yml
@@ -3,31 +3,31 @@ Name: silverstripe-forager-extensions
 ---
 SilverStripe\ORM\FieldType\DBField:
   extensions:
-    - SilverStripe\Forager\Extensions\DBFieldExtension
+    SilverStripeForagerDBFieldExtension: SilverStripe\Forager\Extensions\DBFieldExtension
 
 SilverStripe\ORM\FieldType\DBDate:
   extensions:
-    - SilverStripe\Forager\Extensions\DBDateExtension
+    SilverStripeForagerDBDateExtension: SilverStripe\Forager\Extensions\DBDateExtension
 
 SilverStripe\ORM\FieldType\DBBoolean:
   extensions:
-    - SilverStripe\Forager\Extensions\DBBooleanExtension
+    SilverStripeForagerDBBooleanExtension: SilverStripe\Forager\Extensions\DBBooleanExtension
 
 SilverStripe\ORM\FieldType\DBHTMLText:
   extensions:
-    - SilverStripe\Forager\Extensions\DBHTMLFieldExtension
+    SilverStripeForagerDBHTMLFieldExtension: SilverStripe\Forager\Extensions\DBHTMLFieldExtension
 
 SilverStripe\ORM\FieldType\DBHTMLVarchar:
   extensions:
-    - SilverStripe\Forager\Extensions\DBHTMLFieldExtension
+    SilverStripeForagerDBHTMLFieldExtension: SilverStripe\Forager\Extensions\DBHTMLFieldExtension
 
 Symbiote\QueuedJobs\Controllers\QueuedJobsAdmin:
   extensions:
-    - SilverStripe\Forager\Extensions\QueuedJobsAdminExtension
+    SilverStripeForagerQueuedJobsAdminExtension: SilverStripe\Forager\Extensions\QueuedJobsAdminExtension
 
 Symbiote\QueuedJobs\Services\QueuedJobService:
   extensions:
-    - SilverStripe\Forager\Extensions\JobRetryExtension
+    SilverStripeForagerJobRetryExtension: SilverStripe\Forager\Extensions\JobRetryExtension
 
 ---
 Name: 'silverstripe-forager-cms'
@@ -44,7 +44,7 @@ Name: silverstripe-forager-form-extension
 ---
 SilverStripe\AssetAdmin\Forms\FileFormFactory:
   extensions:
-    - SilverStripe\Forager\Extensions\SearchFormFactoryExtension
+    SearchFormFactoryExtension: SilverStripe\Forager\Extensions\SearchFormFactoryExtension
 
 SilverStripe\Forager\Extensions\SearchFormFactoryExtension:
   exclude_classes:
@@ -58,3 +58,10 @@ Only:
 SilverStripe\Assets\File:
   extensions:
     ForagerFileExtension: SilverStripe\Forager\Extensions\SearchServiceExtension
+
+---
+Name: silverstripe-forager-dbbuild-extension
+---
+SilverStripe\Dev\Command\DbBuild:
+  extensions:
+    SilverStripeForagerDbBuildExtension: SilverStripe\Forager\Extensions\DbBuildExtension

--- a/src/Extensions/DbBuildExtension.php
+++ b/src/Extensions/DbBuildExtension.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace SilverStripe\Forager\Extensions;
+
+use SilverStripe\Core\Config\Configurable;
+use SilverStripe\Core\Extension;
+use SilverStripe\Dev\Command\DbBuild;
+use SilverStripe\Forager\Interfaces\IndexingInterface;
+use SilverStripe\Forager\Service\Traits\ServiceAware;
+use SilverStripe\Forager\Tasks\SearchConfigure;
+use SilverStripe\PolyExecution\PolyOutput;
+
+/**
+ * @extends Extension<DbBuild>
+ */
+class DbBuildExtension extends Extension
+{
+
+    use ServiceAware;
+    use Configurable;
+
+    private static array $dependencies = [
+        'indexService' => '%$' . IndexingInterface::class,
+    ];
+
+    /**
+     * @config
+     */
+    private static bool $enabled = true;
+
+    protected function onAfterBuild(PolyOutput $output): void
+    {
+        if (!static::config()->get('enabled')) {
+            return;
+        }
+
+        $task = SearchConfigure::create($this->getIndexService());
+        $task->doConfigure($output);
+    }
+
+}

--- a/src/Extensions/SearchServiceExtension.php
+++ b/src/Extensions/SearchServiceExtension.php
@@ -19,7 +19,6 @@ use SilverStripe\Forms\FieldList;
 use SilverStripe\Forms\ReadonlyField;
 use SilverStripe\ORM\DataObject;
 use SilverStripe\Versioned\Versioned;
-use Throwable;
 
 /**
  * The extension that provides implicit indexing features to DataObjects
@@ -153,23 +152,6 @@ class SearchServiceExtension extends Extension
         }
 
         $this->owner->removeFromIndexes();
-    }
-
-    /**
-     * On dev/build ensure that the indexer settings are up to date
-     */
-    protected function onAfterBuild(): void
-    {
-        // Wrap this in a try-catch so that dev/build can continue (with warnings) when no service has been set
-        try {
-            // This extension can be applied to many DataObjects; let's make sure we only run this once
-            if (!$this->hasConfigured) {
-                $this->getIndexService()->configure();
-                $this->hasConfigured = true;
-            }
-        } catch (Throwable $e) {
-            user_error(sprintf('Unable to configure search indexes: %s', $e->getMessage()), E_USER_WARNING);
-        }
     }
 
 }


### PR DESCRIPTION
avoids having it on dataobject and needing to check if it has already run

also changes the output so its a bit easier to tell what's going on:
errors:
<img width="341" height="138" alt="image" src="https://github.com/user-attachments/assets/9ce83951-8f12-44da-aa51-f65a694c5778" />

task output:
<img width="1410" height="438" alt="image" src="https://github.com/user-attachments/assets/fd3a598b-e8d8-46fc-8164-7a9072c34a0a" />
