### PR TITLE
IndexData and Context for Fluent (and other use-case) support

### DIFF
--- a/_config/config.yml
+++ b/_config/config.yml
@@ -42,3 +42,11 @@ SilverStripe\Core\Injector\Injector:
     constructor:
       configuration: '%$SilverStripe\Forager\Service\IndexConfiguration'
       registry: '%$SilverStripe\Forager\Service\DocumentFetchCreatorRegistry'
+
+  SilverStripe\Forager\Service\IndexData:
+    properties:
+      contexts:
+        default:
+          SilverstripeForagerLiveIndexDataContext: '%$SilverStripe\Forager\Service\LiveIndexDataContext'
+
+

--- a/docs/en/06_customising_add_search_service.md
+++ b/docs/en/06_customising_add_search_service.md
@@ -56,7 +56,7 @@ it is assigned to. Be sure to check each item's `shouldIndex()` method, as well.
 Return value should be the unique ID of the document.
 
 ```php
-public function addDocument(DocumentInterface $document, array $indexSuffixes): ?string
+public function addDocument(array $indexSuffix, DocumentInterface $document): ?string
 {
     if (!$document->shouldIndex()) {
         return null;
@@ -81,7 +81,7 @@ public function addDocument(DocumentInterface $document, array $indexSuffixes): 
 **Tip**: Consider passing `DocumentBuilder` and `IndexConfiguration` as a constructor 
 arguments to your indexing service.
 
-### addDocuments(array $documents, array $indexSuffixes): self
+### addDocuments(array $indexSuffix, array $documents): self
 
 Same as `addDocument()`, but accepts an array of `DocumentInterface` objects. It is recommended
 that the `addDocument()` method works as a proxy for `addDocuments()`, e.g. 
@@ -103,7 +103,7 @@ Removes a document from its indexes.
 Return value should be the unique ID of the document.
 
 ```php
-public function removeDocument(DocumentInterface $document): ?string
+public function removeDocument(string $indexSuffix, DocumentInterface $document): ?string
 {
     $indexes = IndexConfiguration::singleton()->getIndexConfigurationsForDocument($document);
     

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -178,4 +178,10 @@
             <property name="linesCountAfterWhenLastInLastCaseOrDefault" value="0"/>
         </properties>
     </rule>
+
+    <rule ref="SlevomatCodingStandard.Variables.UnusedVariable">
+        <properties>
+            <property name="ignoreUnusedValuesWhenOnlyKeysAreUsedInForeach" value="true"/>
+        </properties>
+    </rule>
 </ruleset>

--- a/src/Admin/SearchIndexAdmin.php
+++ b/src/Admin/SearchIndexAdmin.php
@@ -33,10 +33,11 @@ use SilverStripe\Security\PermissionProvider;
 use Symbiote\QueuedJobs\DataObjects\QueuedJobDescriptor;
 use Symbiote\QueuedJobs\Services\QueuedJob;
 
-class SearchAdmin extends LeftAndMain implements PermissionProvider
+class SearchIndexAdmin extends LeftAndMain implements PermissionProvider
 {
 
     private const string PERMISSION_ACCESS = 'CMS_ACCESS_SearchAdmin';
+
     private const string PERMISSION_REINDEX = 'SearchAdmin_ReIndex';
 
     private static string $url_segment = 'search-indexing';
@@ -196,26 +197,29 @@ class SearchAdmin extends LeftAndMain implements PermissionProvider
         $configuration = SearchServiceExtension::singleton()->getConfiguration();
 
         foreach ($configuration->getIndexConfigurations() as $indexSuffix => $data) {
-            $localCount = 0;
+            $indexData = $configuration->getIndexDataForSuffix($indexSuffix);
+            $indexData->withIndexContext(function () use ($configuration, $indexSuffix, $indexer, $list): void {
+                $localCount = 0;
 
-            foreach ($configuration->getClassesForIndex($indexSuffix) as $class) {
-                $query = new DataQuery($class);
-                $query->where('SearchIndexed IS NOT NULL');
+                foreach ($configuration->getIndexDataForSuffix($indexSuffix)->getClasses() as $class) {
+                    $query = new DataQuery($class);
+                    $query->where('SearchIndexed IS NOT NULL');
 
-                if (property_exists($class, 'ShowInSearch')) {
-                    $query->where('ShowInSearch = 1');
+                    if (property_exists($class, 'ShowInSearch')) {
+                        $query->where('ShowInSearch = 1');
+                    }
+
+                    $this->extend('updateQuery', $query, $data);
+                    $localCount += $query->count();
                 }
 
-                $this->extend('updateQuery', $query, $data);
-                $localCount += $query->count();
-            }
-
-            $result = new IndexedDocumentsResult();
-            $result->IndexName = IndexConfiguration::singleton()->environmentizeIndex($indexSuffix);
-            $result->IndexSuffix = $indexSuffix;
-            $result->DBDocs = $localCount;
-            $result->RemoteDocs = $indexer->getDocumentTotal($indexSuffix);
-            $list->push($result);
+                $result = new IndexedDocumentsResult();
+                $result->IndexName = IndexConfiguration::singleton()->environmentizeIndex($indexSuffix);
+                $result->IndexSuffix = $indexSuffix;
+                $result->DBDocs = $localCount;
+                $result->RemoteDocs = $indexer->getDocumentTotal($indexSuffix);
+                $list->push($result);
+            });
         }
 
         $this->extend('updateDocumentList', $list);

--- a/src/DataObject/DataObjectBatchProcessor.php
+++ b/src/DataObject/DataObjectBatchProcessor.php
@@ -22,18 +22,18 @@ class DataObjectBatchProcessor extends BatchProcessor
      * @param DocumentInterface[] $documents
      * @throws ValidationException
      */
-    public function removeDocuments(array $documents, array $indexSuffixes): array
+    public function removeDocuments(string $indexSuffix, array $documents): array
     {
         $timestamp = DBDatetime::now()->getTimestamp() - $this->config()->get('buffer_seconds');
 
         // Remove the DataObjects, ignore dependencies
-        $job = IndexJob::create($documents, $indexSuffixes, Indexer::METHOD_DELETE, null, false);
+        $job = IndexJob::create($indexSuffix, $documents, Indexer::METHOD_DELETE, null, false);
         $this->run($job);
 
         foreach ($documents as $doc) {
             // Indexer::METHOD_ADD as default parameter make sure we check first its related documents
             // and decide whether we should delete or update them automatically.
-            $childJob = RemoveDataObjectJob::create($doc, $indexSuffixes, $timestamp);
+            $childJob = RemoveDataObjectJob::create($indexSuffix, $doc, $timestamp);
             $this->run($childJob);
         }
 

--- a/src/DataObject/DataObjectDocument.php
+++ b/src/DataObject/DataObjectDocument.php
@@ -503,6 +503,12 @@ class DataObjectDocument implements
         $this->dataObject = $dataObject;
 
         foreach (static::config()->get('dependencies') as $name => $service) {
+            $getter = 'get' . $name;
+
+            if ($this->$getter() !== null) {
+                continue;
+            }
+
             $method = 'set' . $name;
             $this->$method(Injector::inst()->get($service));
         }

--- a/src/DataObject/DataObjectFetcher.php
+++ b/src/DataObject/DataObjectFetcher.php
@@ -91,7 +91,13 @@ class DataObjectFetcher implements DocumentFetcherInterface
 
     public function getTotalBatches(): int
     {
-        return max(1, (int) ceil($this->getTotalDocuments() / $this->getBatchSize()));
+        $total = $this->getTotalDocuments();
+
+        if ($total === 0) {
+            return 0;
+        }
+
+        return max(1, (int) ceil($total / $this->getBatchSize()));
     }
 
     public function createDocument(array $data): ?DocumentInterface

--- a/src/Extensions/SearchServiceExtension.php
+++ b/src/Extensions/SearchServiceExtension.php
@@ -111,7 +111,9 @@ class SearchServiceExtension extends Extension
         $document = DataObjectDocument::create($this->owner);
         $indexSuffixes = IndexConfiguration::singleton()->getIndexSuffixes();
 
-        $this->getBatchProcessor()->addDocuments([$document], $indexSuffixes);
+        foreach ($indexSuffixes as $indexSuffix) {
+            $this->getBatchProcessor()->addDocuments($indexSuffix, [$document]);
+        }
     }
 
     /**
@@ -122,7 +124,9 @@ class SearchServiceExtension extends Extension
         $document = DataObjectDocument::create($this->owner)->setShouldFallbackToLatestVersion();
         $indexSuffixes = IndexConfiguration::singleton()->getIndexSuffixes();
 
-        $this->getBatchProcessor()->removeDocuments([$document], $indexSuffixes);
+        foreach ($indexSuffixes as $indexSuffix) {
+            $this->getBatchProcessor()->removeDocuments($indexSuffix, [$document]);
+        }
     }
 
     /**

--- a/src/Interfaces/BatchDocumentInterface.php
+++ b/src/Interfaces/BatchDocumentInterface.php
@@ -7,16 +7,14 @@ interface BatchDocumentInterface
 
     /**
      * @param DocumentInterface[] $documents
-     * @param string[] $indexSuffixes
      * @return array Array of IDs of the Documents added
      */
-    public function addDocuments(array $documents, array $indexSuffixes): array;
+    public function addDocuments(string $indexSuffix, array $documents): array;
 
     /**
      * @param DocumentInterface[] $documents
-     * @param string[] $indexSuffixes
      * @return array Array of IDs of the Documents removed
      */
-    public function removeDocuments(array $documents, array $indexSuffixes): array;
+    public function removeDocuments(string $indexSuffix, array $documents): array;
 
 }

--- a/src/Interfaces/IndexDataContextProvider.php
+++ b/src/Interfaces/IndexDataContextProvider.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace SilverStripe\Forager\Interfaces;
+
+/**
+ * Index Data Contexts can set the environment for which
+ * index operations are made - such as fluent or versioned state
+ */
+interface IndexDataContextProvider
+{
+
+    /**
+     * Contexts are objects of type callable that
+     * take another callable as an argument returns
+     * the result of calling that argument.
+     *
+     * The current IndexData is provided as the second argument
+     *
+     *
+     * ```PHP
+     * public function getContext(): callable {
+     *      return function (callable $next, IndexData $indexData): mixed {
+     *          return Versioned::withVersionedMode(function () use ($next): mixed {
+     *               Versioned::set_stage(Versioned::LIVE);
+     *
+     *               return $next();
+     *           });
+     *       };
+     *   }
+     * ```
+     *
+     * @return callable
+     */
+    public function getContext(): callable;
+
+}

--- a/src/Interfaces/IndexingInterface.php
+++ b/src/Interfaces/IndexingInterface.php
@@ -12,13 +12,13 @@ interface IndexingInterface extends BatchDocumentInterface
      * @return string|null ID of the Document added
      * @throws IndexingServiceException
      */
-    public function addDocument(DocumentInterface $document, array $indexSuffixes): ?string;
+    public function addDocument(string $indexSuffix, DocumentInterface $document): ?string;
 
     /**
      * @return string|null ID of the Document removed
      * @throws IndexingServiceException
      */
-    public function removeDocument(DocumentInterface $document, array $indexSuffixes): ?string;
+    public function removeDocument(string $indexSuffix, DocumentInterface $document): ?string;
 
     /**
      * @throws IndexingServiceException

--- a/src/Jobs/ReindexJob.php
+++ b/src/Jobs/ReindexJob.php
@@ -8,10 +8,10 @@ use SilverStripe\Core\Injector\Injectable;
 use SilverStripe\Forager\Interfaces\DocumentFetcherInterface;
 use SilverStripe\Forager\Service\DocumentFetchCreatorRegistry;
 use SilverStripe\Forager\Service\IndexConfiguration;
+use SilverStripe\Forager\Service\IndexData;
 use SilverStripe\Forager\Service\Indexer;
 use SilverStripe\Forager\Service\Traits\ConfigurationAware;
 use SilverStripe\Forager\Service\Traits\RegistryAware;
-use SilverStripe\Versioned\Versioned;
 use Symbiote\QueuedJobs\Services\QueuedJob;
 
 /**
@@ -65,39 +65,41 @@ class ReindexJob extends BatchJob
             throw new InvalidArgumentException('An index suffix must be specified');
         }
 
-        Versioned::set_stage(Versioned::LIVE);
-
         // Restrict this job to only processing the one index that we specified
-        $this->getConfiguration()->restrictToIndexes([$this->getIndexSuffix()]);
+        $config = $this->getConfiguration()->restrictToIndexes([$this->getIndexSuffix()]);
+        $indexData = $config->getIndexDataForSuffix($this->getIndexSuffix());
 
-        // Can optionally process specifically classes, or all classes
-        $classes = $this->getOnlyClasses() && count($this->getOnlyClasses())
-            ? $this->getOnlyClasses()
-            : $this->getConfiguration()->getSearchableBaseClasses();
+        $indexData->withIndexContext(function (IndexData $indexData): void {
+            // Can optionally process specifically classes, or all classes
+            $classes = $this->getOnlyClasses() && count($this->getOnlyClasses())
+                ? $this->getOnlyClasses()
+                : $indexData->getClasses();
 
-        /** @var DocumentFetcherInterface[] $fetchers */
-        $fetchers = [];
+            /** @var DocumentFetcherInterface[] $fetchers */
+            $fetchers = [];
 
-        foreach ($classes as $class) {
-            // Each class is represented by its own fetcher
-            $fetcher = $this->getRegistry()->getFetcher($class);
+            foreach ($classes as $class) {
+                // Each class is represented by its own fetcher
+                $fetcher = $this->getRegistry()->getFetcher($class);
 
-            if (!$fetcher) {
-                continue;
+                if (!$fetcher) {
+                    continue;
+                }
+
+                $fetchers[$class] = $fetcher;
             }
 
-            $fetchers[$class] = $fetcher;
-        }
+            $steps = array_reduce($fetchers, function (int $total, DocumentFetcherInterface $fetcher) {
+                return $total + $fetcher->getTotalBatches();
+            }, 0);
 
-        $steps = array_reduce($fetchers, function (int $total, DocumentFetcherInterface $fetcher) {
-            return $total + $fetcher->getTotalBatches();
-        }, 0);
+            $this->totalSteps = $steps;
+            $this->isComplete = $steps === 0;
+            $this->currentStep = 0;
+            $this->setFetchers(array_values($fetchers));
+            $this->setFetcherIndex(0);
+        });
 
-        $this->totalSteps = $steps;
-        $this->isComplete = $steps === 0;
-        $this->currentStep = 0;
-        $this->setFetchers(array_values($fetchers));
-        $this->setFetcherIndex(0);
         $this->extend('onAfterSetup');
     }
 
@@ -108,42 +110,49 @@ class ReindexJob extends BatchJob
     {
         $this->currentStep++;
         $this->extend('onBeforeProcess');
-        $fetcher = $this->getFetcher($this->getFetcherIndex());
+        $config = $this->getConfiguration()->restrictToIndexes([$this->getIndexSuffix()]);
+        $indexData = $config->getIndexDataForSuffix($this->getIndexSuffix());
 
-        // We must have finished processing all of our Fetchers
-        if (!$fetcher) {
-            $this->isComplete = true;
+        $indexData->withIndexContext(function (): void {
 
-            return;
-        }
+            $fetcher = $this->getFetcher($this->getFetcherIndex());
 
-        // The Fetcher itself knows what batch size and offset to use. It's ok if this is an empty array. The Indexer
-        // will simply not process anything
-        $documents = $fetcher->fetch();
+            // We must have finished processing all of our Fetchers
+            if (!$fetcher) {
+                $this->isComplete = true;
 
-        // Use the same batch size on the Fetcher for the Indexer
-        $indexer = Indexer::create(
-            $this->getIndexSuffix(),
-            $documents,
-            Indexer::METHOD_ADD,
-            $fetcher->getBatchSize()
-        );
-        $indexer->setProcessDependencies(false);
+                return;
+            }
 
-        while (!$indexer->finished()) {
-            $indexer->processNode();
-        }
+            // The Fetcher itself knows what batch size and offset to use.
+            // It's ok if this is an empty array. The Indexer
+            // will simply not process anything
+            $documents = $fetcher->fetch();
 
-        // Let's check if the Fetcher still has more records for us to process
-        $nextOffset = $fetcher->getOffset() + $fetcher->getBatchSize();
+            // Use the same batch size on the Fetcher for the Indexer
+            $indexer = Indexer::create(
+                $this->getIndexSuffix(),
+                $documents,
+                Indexer::METHOD_ADD,
+                $fetcher->getBatchSize()
+            );
+            $indexer->setProcessDependencies(false);
 
-        if ($nextOffset >= $fetcher->getTotalDocuments()) {
-            // We have finished processing all the records for this Fetcher, so let's move to the next one
-            $this->incrementFetcherIndex();
-        } else {
-            // Keep going with this Fetcher, but move to the next batch
-            $fetcher->incrementOffsetUp();
-        }
+            while (!$indexer->finished()) {
+                $indexer->processNode();
+            }
+
+            // Let's check if the Fetcher still has more records for us to process
+            $nextOffset = $fetcher->getOffset() + $fetcher->getBatchSize();
+
+            if ($nextOffset >= $fetcher->getTotalDocuments()) {
+                // We have finished processing all the records for this Fetcher, so let's move to the next one
+                $this->incrementFetcherIndex();
+            } else {
+                // Keep going with this Fetcher, but move to the next batch
+                $fetcher->incrementOffsetUp();
+            }
+        });
 
         $this->extend('onAfterProcess');
 

--- a/src/Jobs/ReindexJob.php
+++ b/src/Jobs/ReindexJob.php
@@ -123,8 +123,8 @@ class ReindexJob extends BatchJob
 
         // Use the same batch size on the Fetcher for the Indexer
         $indexer = Indexer::create(
+            $this->getIndexSuffix(),
             $documents,
-            [$this->getIndexSuffix()],
             Indexer::METHOD_ADD,
             $fetcher->getBatchSize()
         );

--- a/src/Jobs/RemoveDataObjectJob.php
+++ b/src/Jobs/RemoveDataObjectJob.php
@@ -22,14 +22,14 @@ class RemoveDataObjectJob extends IndexJob
 {
 
     public function __construct(
+        ?string $indexSuffix = null,
         ?DataObjectDocument $document = null,
-        array $indexSuffixes = [],
         ?int $timestamp = null,
         ?int $batchSize = null
     ) {
         // Indexer::METHOD_ADD as default parameter make sure we check first its related documents
         // whether we should delete or update them automatically.
-        parent::__construct([], $indexSuffixes, Indexer::METHOD_ADD, $batchSize);
+        parent::__construct($indexSuffix, [], Indexer::METHOD_ADD, $batchSize);
 
         if ($document !== null) {
             // We do this so that if the Dataobject is deleted, not just unpublished, we can still act upon it

--- a/src/Jobs/RemoveDataObjectJob.php
+++ b/src/Jobs/RemoveDataObjectJob.php
@@ -4,6 +4,7 @@ namespace SilverStripe\Forager\Jobs;
 
 use Exception;
 use SilverStripe\Forager\DataObject\DataObjectDocument;
+use SilverStripe\Forager\Service\IndexConfiguration;
 use SilverStripe\Forager\Service\Indexer;
 use SilverStripe\ORM\DataObject;
 use SilverStripe\ORM\FieldType\DBDatetime;
@@ -56,46 +57,50 @@ class RemoveDataObjectJob extends IndexJob
      */
     public function setup(): void
     {
-        /** @var DBDatetime $datetime - set the documents in setup to ensure async */
-        $datetime = DBField::create_field('Datetime', $this->getTimestamp());
-        $archiveDate = $datetime->format($datetime->getISOFormat());
-        $documents = Versioned::withVersionedMode(function () use ($archiveDate) {
-            Versioned::reading_archived_date($archiveDate);
+        $config = IndexConfiguration::singleton();
+        $indexData = $config->getIndexDataForSuffix($this->getIndexSuffix());
+        $indexData->withIndexContext(function (): void {
+            /** @var DBDatetime $datetime - set the documents in setup to ensure async */
+            $datetime = DBField::create_field('Datetime', $this->getTimestamp());
+            $archiveDate = $datetime->format($datetime->getISOFormat());
+            $documents = Versioned::withVersionedMode(function () use ($archiveDate) {
+                Versioned::reading_archived_date($archiveDate);
 
-            $currentDocument = $this->getDocument();
-            // Go back in time to find out what the owners were before unpublish
-            $dependentDocs = $currentDocument->getDependentDocuments();
+                $currentDocument = $this->getDocument();
+                // Go back in time to find out what the owners were before unpublish
+                $dependentDocs = $currentDocument->getDependentDocuments();
 
-            // refetch everything on the live stage
-            Versioned::set_stage(Versioned::LIVE);
+                // refetch everything on the live stage
+                Versioned::set_stage(Versioned::LIVE);
 
-            return array_reduce(
-                $dependentDocs,
-                function (array $carry, DataObjectDocument $doc) {
-                    $record = DataObject::get_by_id($doc->getSourceClass(), $doc->getDataObject()->ID);
+                return array_reduce(
+                    $dependentDocs,
+                    function (array $carry, DataObjectDocument $doc) {
+                        $record = DataObject::get_by_id($doc->getSourceClass(), $doc->getDataObject()->ID);
 
-                    // Since SiteTree::onBeforeDelete recursively deletes the child pages,
-                    // they end up not found on a live environment which breaks DataObjectDocument::_constructor
-                    if ($record) {
-                        $document = DataObjectDocument::create($record);
+                        // Since SiteTree::onBeforeDelete recursively deletes the child pages,
+                        // they end up not found on a live environment which breaks DataObjectDocument::_constructor
+                        if ($record) {
+                            $document = DataObjectDocument::create($record);
+                            $carry[$document->getIdentifier()] = $document;
+
+                            return $carry;
+                        }
+
+                        // Taking into account that this queued job has a reference of existing child pages
+                        // We need to make sure that we are able to send these pages to ElasticSearch etc. for removal
+                        $oldRecord = $doc->getDataObject();
+                        $document = DataObjectDocument::create($oldRecord);
                         $carry[$document->getIdentifier()] = $document;
 
                         return $carry;
-                    }
+                    },
+                    []
+                );
+            });
 
-                    // Taking into account that this queued job has a reference of existing child pages
-                    // We need to make sure that we are able to send these pages to ElasticSearch etc. for removal
-                    $oldRecord = $doc->getDataObject();
-                    $document = DataObjectDocument::create($oldRecord);
-                    $carry[$document->getIdentifier()] = $document;
-
-                    return $carry;
-                },
-                []
-            );
+            $this->setDocuments($documents);
         });
-
-        $this->setDocuments($documents);
 
         parent::setup();
     }

--- a/src/Service/BatchProcessor.php
+++ b/src/Service/BatchProcessor.php
@@ -27,9 +27,9 @@ class BatchProcessor implements BatchDocumentInterface
      * @param DocumentInterface[] $documents
      * @throws Exception
      */
-    public function addDocuments(array $documents, array $indexSuffixes): array
+    public function addDocuments(string $indexSuffix, array $documents): array
     {
-        $job = IndexJob::create($documents, $indexSuffixes);
+        $job = IndexJob::create($indexSuffix, $documents);
         $this->run($job);
 
         return [];
@@ -39,9 +39,9 @@ class BatchProcessor implements BatchDocumentInterface
      * @param DocumentInterface[] $documents
      * @throws Exception
      */
-    public function removeDocuments(array $documents, array $indexSuffixes): array
+    public function removeDocuments(string $indexSuffix, array $documents): array
     {
-        $job = IndexJob::create($documents, $indexSuffixes, Indexer::METHOD_DELETE);
+        $job = IndexJob::create($indexSuffix, $documents, Indexer::METHOD_DELETE);
         $this->run($job);
 
         return [];

--- a/src/Service/IndexConfiguration.php
+++ b/src/Service/IndexConfiguration.php
@@ -299,10 +299,10 @@ class IndexConfiguration
     {
         $batchSizes = [];
         // Fetch all index configurations (these might be filtered if restrictToIndexes has been set)
-        $indexSuffixes = $this->getIndexConfigurations();
+        $indexConfigurations = $this->getIndexConfigurations();
 
         // Loop through each potential index configuration
-        foreach ($indexSuffixes as $config) {
+        foreach ($indexConfigurations as $config) {
             $includedClasses = $config['includeClasses'] ?? [];
 
             foreach ($includedClasses as $spec) {

--- a/src/Service/IndexData.php
+++ b/src/Service/IndexData.php
@@ -1,0 +1,286 @@
+<?php
+
+namespace SilverStripe\Forager\Service;
+
+use InvalidArgumentException;
+use SilverStripe\Core\Extensible;
+use SilverStripe\Core\Injector\Injectable;
+use SilverStripe\Forager\DataObject\DataObjectDocument;
+use SilverStripe\Forager\Exception\IndexConfigurationException;
+use SilverStripe\Forager\Interfaces\IndexDataContextProvider;
+use SilverStripe\Forager\Schema\Field;
+
+/**
+ * Class to contain configuration data for a single index suffix
+ */
+class IndexData
+{
+
+    use Injectable;
+    use Extensible;
+
+    public const string CONTEXT_KEY = 'context';
+    public const string CONTEXT_KEY_DEFAULT = 'default';
+
+    public function __construct(private array $data, private string $suffix)
+    {
+    }
+
+    /**
+     * Index contexts
+     *
+     * @var array
+     */
+    public array $contexts = [];
+
+    public function getData(): array
+    {
+        return $this->data;
+    }
+
+    public function getSuffix(): string
+    {
+        return $this->suffix;
+    }
+
+    public function getClassData(): array
+    {
+        return $this->data['includeClasses'] ?? [];
+    }
+
+    public function getClassConfig(string $class): ?array
+    {
+        $classData = $this->getClassData();
+
+        if (!array_key_exists($class, $classData)) {
+            return null;
+        }
+
+        $spec = $classData[$class];
+
+        if (!is_array($spec)) {
+            return null;
+        }
+
+        return $classData[$class];
+    }
+
+    /**
+     * @return string[]
+     */
+    public function getClasses(): array
+    {
+        $classes = $this->getClassData() ?? [];
+        $result = [];
+
+        foreach ($classes as $className => $spec) {
+            if ($spec === false) {
+                continue;
+            }
+
+            $result[] = $className;
+        }
+
+        return $result;
+    }
+
+    public function getContextKey(): string
+    {
+        $key = static::CONTEXT_KEY_DEFAULT;
+
+        if (!array_key_exists(static::CONTEXT_KEY, $this->data)) {
+            return $key;
+        }
+
+        return $this->data[static::CONTEXT_KEY];
+    }
+
+    /**
+     * With Index Context wrapper function
+     * withIndexContext will execute the provided callback
+     * within any registered IndexDataContextProvider functions.
+     * This is used at a top level way to set global operational contexts
+     * such as Versioned reading mode or Fluent state per index.
+     *
+     * @param callable $callback
+     * @return void
+     * @see SilverStripe\Forager\Interfaces\IndexDataContextProvider
+     */
+    public function withIndexContext(callable $callback): void
+    {
+        $contextKey = $this->getContextKey();
+        $contexts = $this->contexts;
+
+        if (!array_key_exists($contextKey, $contexts)) {
+            throw new InvalidArgumentException(sprintf('No context configured for key: "%s"', $contextKey));
+        }
+
+        $context = $contexts[$contextKey];
+
+        $wrappers = array_map(
+            function (IndexDataContextProvider $provider) {
+                return $provider->getContext();
+            },
+            array_values($context)
+        );
+
+        $next = function () use ($callback): mixed {
+            return $callback($this);
+        };
+
+        foreach (array_reverse($wrappers) as $wrapper) {
+            $next = function () use ($wrapper, $next): mixed {
+                return $wrapper($next, $this);
+            };
+        }
+
+        $next();
+    }
+
+    public function getFields(): array
+    {
+        $fields = [];
+
+        $defaultFields = [
+            // Default fields that relate to our DataObjects
+            // @todo don't hardcode DataObjectDocument in here
+            IndexConfiguration::singleton()->getSourceClassField(),
+            DataObjectDocument::config()->get('base_class_field'),
+            DataObjectDocument::config()->get('record_id_field'),
+        ];
+
+        foreach ($defaultFields as $defaultField) {
+            $fields[$defaultField] = new Field(
+                $defaultField,
+                null,
+                []
+            );
+        }
+
+        $classes = $this->getClasses();
+
+        foreach ($classes as $class) {
+            $classFields = $this->getFieldsForClass($class);
+
+            if (!$classFields) {
+                continue;
+            }
+
+            $fields = array_merge($fields, $classFields);
+        }
+
+        return $fields;
+    }
+
+    public function getFieldsForClass(string $class): ?array
+    {
+        $candidate = $class;
+        $fieldObjs = [];
+
+        while ($candidate) {
+            $spec = $this->getClassConfig($candidate);
+
+            if (!$spec) {
+                $candidate = get_parent_class($candidate);
+
+                continue;
+            }
+
+            $fields = $spec['fields'] ?? [];
+
+            foreach ($fields as $searchName => $data) {
+                if ($data === false) {
+                    continue;
+                }
+
+                $fieldConfig = (array) $data;
+                // This is a callout to a common misconfiguration that will result in developers receiving an
+                // unexpected field type. The correct yaml format is for this to be part of the "options" object
+                $invalidTypeField = $fieldConfig['type'] ?? null;
+
+                if ($invalidTypeField) {
+                    throw new IndexConfigurationException(
+                        'Field configuration for "type" should be defined under the "options" object.'
+                        . ' Please see 02_configuration.md#basic-configuration for an example.'
+                    );
+                }
+
+                $fieldObjs[$searchName] = new Field(
+                    $searchName,
+                    $fieldConfig['property'] ?? null,
+                    $fieldConfig['options'] ?? []
+                );
+            }
+
+            $candidate = get_parent_class($candidate);
+        }
+
+        return $fieldObjs;
+    }
+
+    public function getLowestBatchSize(): int
+    {
+        $classData = $this->getClassData();
+        $batchSizes = [];
+
+        foreach ($classData as $spec) {
+            // Check to see if a batch size was defined for this class
+            $batchSize = $spec['batch_size'] ?? null;
+
+            if (!$batchSize) {
+                continue;
+            }
+
+            // In the case where there are multiple candidate configurations, we'll keep them all and then pick the
+            // lowest at the end
+            $batchSizes[] = $batchSize;
+        }
+
+        if (!$batchSizes) {
+            // fall back to global index configuration
+            return IndexConfiguration::singleton()->getBatchSize();
+        }
+
+        return min($batchSizes);
+    }
+
+    public function getLowestBatchSizeForClass(string $class): int
+    {
+        $candidate = $class;
+        $batchSizes = [];
+
+        while ($candidate) {
+            $spec = $this->getClassConfig($candidate);
+
+            if (!$spec) {
+                $candidate = get_parent_class($candidate);
+
+                continue;
+            }
+
+            // Check to see if a batch size was defined for this class
+            $batchSize = $spec['batch_size'] ?? null;
+
+            if (!$batchSize) {
+                $candidate = get_parent_class($candidate);
+
+                continue;
+            }
+
+            // In the case where there are multiple candidate configurations, we'll keep them all and then pick the
+            // lowest at the end
+            $batchSizes[] = $batchSize;
+
+            $candidate = get_parent_class($candidate);
+        }
+
+        if (!$batchSizes) {
+            // fall back to global index configuration
+            return IndexConfiguration::singleton()->getBatchSize();
+        }
+
+        // Return the lowest defined batch size
+        return min($batchSizes);
+    }
+
+}

--- a/src/Service/LiveIndexDataContext.php
+++ b/src/Service/LiveIndexDataContext.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace SilverStripe\Forager\Service;
+
+use SilverStripe\Core\Injector\Injectable;
+use SilverStripe\Forager\Interfaces\IndexDataContextProvider;
+use SilverStripe\Versioned\Versioned;
+
+class LiveIndexDataContext implements IndexDataContextProvider
+{
+
+    use Injectable;
+
+    public function getContext(): callable
+    {
+        return function (callable $next): mixed {
+            return Versioned::withVersionedMode(function () use ($next): mixed {
+                Versioned::set_stage(Versioned::LIVE);
+
+                return $next();
+            });
+        };
+    }
+
+}

--- a/src/Service/Naive/NaiveSearchService.php
+++ b/src/Service/Naive/NaiveSearchService.php
@@ -8,22 +8,22 @@ use SilverStripe\Forager\Interfaces\IndexingInterface;
 class NaiveSearchService implements IndexingInterface
 {
 
-    public function addDocument(DocumentInterface $document, array $indexSuffixes): ?string
+    public function addDocument(string $indexSuffix, DocumentInterface $document): ?string
     {
         return null;
     }
 
-    public function addDocuments(array $documents, array $indexSuffixes): array
+    public function addDocuments(string $indexSuffix, array $documents): array
     {
         return [];
     }
 
-    public function removeDocument(DocumentInterface $document, array $indexSuffixes): ?string
+    public function removeDocument(string $indexSuffix, DocumentInterface $document): ?string
     {
         return null;
     }
 
-    public function removeDocuments(array $documents, array $indexSuffixes): array
+    public function removeDocuments(string $indexSuffix, array $documents): array
     {
         return [];
     }

--- a/src/Tasks/SearchReindex.php
+++ b/src/Tasks/SearchReindex.php
@@ -49,16 +49,16 @@ class SearchReindex extends BuildTask
         }
 
         // Loop through all available indexes (with the above filter applied, if relevant)
-        foreach (array_keys($indexConfiguration->getIndexConfigurations()) as $index) {
+        foreach (array_keys($indexConfiguration->getIndexConfigurations()) as $indexSuffix) {
             // If a specific class has been requested, then we'll limit ourselves to that, otherwise get all classes
             // for the index
             $classes = $onlyClass
                 ? [$onlyClass]
-                : $indexConfiguration->getClassesForIndex($index);
+                : $indexConfiguration->getIndexDataForSuffix($indexSuffix)->getClasses();
 
             foreach ($classes as $class) {
                 // Create a job for this class and index
-                $job = ReindexJob::create($index, [$class]);
+                $job = ReindexJob::create($indexSuffix, [$class]);
 
                 if ($indexConfiguration->shouldUseSyncJobs()) {
                     // This can be a very memory and time intensive process

--- a/tests/DataObject/DataObjectBatchProcessorTest.php
+++ b/tests/DataObject/DataObjectBatchProcessorTest.php
@@ -23,7 +23,7 @@ class DataObjectBatchProcessorTest extends SapphireTest
 
     public function testRemoveDocuments(): void
     {
-        $config = $this->mockConfig();
+        $config = $this->mockConfig(true);
         $config->set('use_sync_jobs', true);
 
         Config::modify()->set(

--- a/tests/DataObject/DataObjectBatchProcessorTest.php
+++ b/tests/DataObject/DataObjectBatchProcessorTest.php
@@ -58,11 +58,11 @@ class DataObjectBatchProcessorTest extends SapphireTest
         $processor = new DataObjectBatchProcessor(IndexConfiguration::singleton());
 
         $processor->removeDocuments(
+            'index1',
             [
                 DataObjectDocumentFake::create(DataObjectFake::create()),
                 DataObjectDocumentFake::create(DataObjectFake::create()),
-            ],
-            ['index1']
+            ]
         );
     }
 

--- a/tests/DataObject/DataObjectDocumentTest.php
+++ b/tests/DataObject/DataObjectDocumentTest.php
@@ -578,16 +578,14 @@ class DataObjectDocumentTest extends SapphireTest
         $doc = DataObjectDocument::create($dataObject)->setShouldFallbackToLatestVersion(true);
         $dataObject->doArchive();
 
-        /** @var DataObjectDocument $serialDoc */
-        $serialDoc = unserialize(serialize($doc));
-        $this->assertEquals($id, $serialDoc->getDataObject()->ID);
-
         $doc->setShouldFallbackToLatestVersion(false);
         $this->expectExceptionMessage(
             sprintf('DataObject %s : %s does not exist', DataObjectFakeVersioned::class, $id)
         );
 
-        unserialize(serialize($doc));
+        /** @var DataObjectDocument $newDocument */
+        $newDocument = unserialize(serialize($doc));
+        $newDocument->getDataObject();
     }
 
     public function testIndexDataObjectDocument(): void
@@ -624,7 +622,7 @@ class DataObjectDocumentTest extends SapphireTest
                 ]
             );
 
-            $indexer = Indexer::create([$doc], ['index1']);
+            $indexer = Indexer::create('index1', [$doc]);
             $indexer->setIndexService($service = new ServiceFake());
             $indexer->setBatchSize(1);
             $indexer->processNode();
@@ -638,7 +636,7 @@ class DataObjectDocumentTest extends SapphireTest
             $dataObject->flushCache();
             $doc = DataObjectDocument::create($dataObject);
 
-            $indexer = Indexer::create([$doc], ['index1']);
+            $indexer = Indexer::create('index1', [$doc]);
             $indexer->setIndexService($service = new ServiceFake());
             $indexer->setBatchSize(1);
             $indexer->processNode();

--- a/tests/Fake/IndexConfigurationFake.php
+++ b/tests/Fake/IndexConfigurationFake.php
@@ -77,11 +77,6 @@ class IndexConfigurationFake extends IndexConfiguration
         return $this->override[__FUNCTION__][$class] ?? parent::isClassIndexed($class);
     }
 
-    public function getClassesForIndex(string $indexSuffix): array
-    {
-        return $this->override[__FUNCTION__][$indexSuffix] ?? parent::getClassesForIndex($indexSuffix);
-    }
-
     public function getSearchableClasses(): array
     {
         return $this->override[__FUNCTION__] ?? parent::getSearchableClasses();
@@ -95,11 +90,6 @@ class IndexConfigurationFake extends IndexConfiguration
     public function getFieldsForClass(string $class): ?array
     {
         return $this->override[__FUNCTION__][$class] ?? parent::getFieldsForClass($class);
-    }
-
-    public function getFieldsForIndex(string $index): array
-    {
-        return $this->override[__FUNCTION__][$index] ?? parent::getFieldsForIndex($index);
     }
 
     public function getIndexPrefix(): ?string

--- a/tests/Fake/ServiceFake.php
+++ b/tests/Fake/ServiceFake.php
@@ -15,37 +15,37 @@ class ServiceFake implements IndexingInterface
 
     public int $maxDocSize = 1000;
 
-    public function addDocument(DocumentInterface $document, array $indexSuffixes): ?string
+    public function addDocument(string $indexSuffix, DocumentInterface $document): ?string
     {
         $this->documents[$document->getIdentifier()] = DocumentBuilder::singleton()->toArray($document);
 
         return $document->getIdentifier();
     }
 
-    public function addDocuments(array $documents, array $indexSuffixes): array
+    public function addDocuments(string $indexSuffix, array $documents): array
     {
         $ids = [];
 
         foreach ($documents as $document) {
-            $ids[] = $this->addDocument($document, $indexSuffixes);
+            $ids[] = $this->addDocument($indexSuffix, $document);
         }
 
         return $ids;
     }
 
-    public function removeDocument(DocumentInterface $document, array $indexSuffixes): ?string
+    public function removeDocument(string $indexSuffix, DocumentInterface $document): ?string
     {
         unset($this->documents[$document->getIdentifier()]);
 
         return $document->getIdentifier();
     }
 
-    public function removeDocuments(array $documents, array $indexSuffixes): array
+    public function removeDocuments(string $indexSuffix, array $documents): array
     {
         $ids = [];
 
         foreach ($documents as $document) {
-            $ids[] = $this->removeDocument($document, $indexSuffixes);
+            $ids[] = $this->removeDocument($indexSuffix, $document);
         }
 
         return $ids;

--- a/tests/Jobs/RemoveDataObjectJobTest.php
+++ b/tests/Jobs/RemoveDataObjectJobTest.php
@@ -39,7 +39,7 @@ class RemoveDataObjectJobTest extends SapphireTest
 
     public function testJob(): void
     {
-        $config = $this->mockConfig();
+        $config = $this->mockConfig(true);
 
         $config->set(
             'getSearchableClasses',

--- a/tests/Jobs/RemoveDataObjectJobTest.php
+++ b/tests/Jobs/RemoveDataObjectJobTest.php
@@ -81,11 +81,8 @@ class RemoveDataObjectJobTest extends SapphireTest
         // Queue up a job to remove our Tag, the result should be that any related DataObject (DOs that have this Tag
         // assigned to them) are added as related Documents
         $job = RemoveDataObjectJob::create(
+            'index1',
             DataObjectDocument::create($tag),
-            [
-                'index1',
-                'index2',
-            ]
         );
         $job->setup();
 
@@ -136,15 +133,16 @@ class RemoveDataObjectJobTest extends SapphireTest
     {
         $this->mockConfig(true);
 
-        $job = RemoveDataObjectJob::create();
+        $job = RemoveDataObjectJob::create('index1');
 
         $this->assertNull($job->getDocument());
         $this->assertNotNull($job->getTimestamp());
         // Should be the lowest define batch_size across our index configuration
         $this->assertEquals(5, $job->getBatchSize());
 
-        $job = RemoveDataObjectJob::create(null, [], null, 33);
+        $job = RemoveDataObjectJob::create('index1', null, null, 33);
 
+        $this->assertEquals('index1', $job->getIndexSuffix());
         $this->assertNull($job->getDocument());
         $this->assertNotNull($job->getTimestamp());
         // Should be the batch_size that was explicitly set

--- a/tests/Jobs/RemoveRelatedDataObjectJobTest.php
+++ b/tests/Jobs/RemoveRelatedDataObjectJobTest.php
@@ -145,7 +145,7 @@ class RemoveRelatedDataObjectJobTest extends SapphireTest
 
         // Queue up a job to remove a page with child pages are added as related documents
         $pageDoc = DataObjectDocument::create($pageOne);
-        $job = RemoveDataObjectJob::create($pageDoc);
+        $job = RemoveDataObjectJob::create('index1', $pageDoc);
         $job->setup();
 
         // Creating this job does not necessarily mean to delete documents from index
@@ -186,6 +186,7 @@ class RemoveRelatedDataObjectJobTest extends SapphireTest
         // Queue up a job to remove our Tag, the result should be that any related DataObject (DOs that have this Tag
         // assigned to them) are added as related Documents
         $job = RemoveDataObjectJob::create(
+            'index1',
             DataObjectDocument::create($tagFour)
         );
         $job->setup();
@@ -253,6 +254,7 @@ class RemoveRelatedDataObjectJobTest extends SapphireTest
         // Queue up a job to remove our Tag, the result should be that any related DataObject (DOs that have this Tag
         // assigned to them) are added as related Documents
         $job2 = RemoveDataObjectJob::create(
+            'index1',
             DataObjectDocument::create($tagFive)
         );
         $job2->setup();
@@ -357,6 +359,7 @@ class RemoveRelatedDataObjectJobTest extends SapphireTest
         $imageFive = $this->objFromFixture(ImageFake::class, 'five');
         // Queue up a job to remove our Image, the result should be that any related DataObject
         $job = RemoveDataObjectJob::create(
+            'index1',
             DataObjectDocument::create($imageFive)
         );
         $job->setup();

--- a/tests/Jobs/RemoveRelatedDataObjectJobTest.php
+++ b/tests/Jobs/RemoveRelatedDataObjectJobTest.php
@@ -64,7 +64,7 @@ class RemoveRelatedDataObjectJobTest extends SapphireTest
         $this->objFromFixture(TagFake::class, 'five')->publishRecursive();
         $this->objFromFixture(TagFake::class, 'six')->publishRecursive();
 
-        $config = $this->mockConfig();
+        $config = $this->mockConfig(true);
 
         $config->set(
             'getSearchableClasses',

--- a/tests/SearchServiceTestTrait.php
+++ b/tests/SearchServiceTestTrait.php
@@ -2,7 +2,6 @@
 
 namespace SilverStripe\Forager\Tests;
 
-use SilverStripe\Control\Controller;
 use SilverStripe\Core\Injector\Injector;
 use SilverStripe\Forager\DataObject\DataObjectDocument;
 use SilverStripe\Forager\Extensions\SearchServiceExtension;
@@ -12,7 +11,6 @@ use SilverStripe\Forager\Tests\Fake\DataObjectFake;
 use SilverStripe\Forager\Tests\Fake\DataObjectFakeAlternate;
 use SilverStripe\Forager\Tests\Fake\IndexConfigurationFake;
 use SilverStripe\Forager\Tests\Fake\ServiceFake;
-use SilverStripe\Security\Member;
 
 trait SearchServiceTestTrait
 {
@@ -47,13 +45,6 @@ trait SearchServiceTestTrait
                                     'field2' => true,
                                 ],
                             ],
-                            Member::class => [
-                                'batch_size' => 50,
-                                'fields' => [
-                                    'field3' => true,
-                                    'field4' => false,
-                                ],
-                            ],
                         ],
                     ],
                     'index2' => [
@@ -62,11 +53,6 @@ trait SearchServiceTestTrait
                                 'batch_size' => 25,
                                 'fields' => [
                                     'field5' => true,
-                                ],
-                            ],
-                            Controller::class => [
-                                'fields' => [
-                                    'field6' => true,
                                 ],
                             ],
                         ],
@@ -99,7 +85,7 @@ trait SearchServiceTestTrait
 
             $dataObject->write();
             $doc = DataObjectDocument::create($dataObject);
-            $service->addDocument($doc, ['index1', 'index2']);
+            $service->addDocument('index1', $doc);
         }
 
         return $service;
@@ -116,7 +102,7 @@ trait SearchServiceTestTrait
 
             $dataObject->write();
             $doc = DataObjectDocument::create($dataObject);
-            $service->addDocument($doc, ['index1', 'index2']);
+            $service->addDocument('index1', $doc);
         }
 
         return $service;

--- a/tests/Service/BatchProcessorTest.php
+++ b/tests/Service/BatchProcessorTest.php
@@ -36,11 +36,11 @@ class BatchProcessorTest extends SapphireTest
 
         $processor = new BatchProcessor($config);
         $processor->addDocuments(
+            'index1',
             [
                 new DocumentFake('Fake', ['test' => 'foo']),
                 new DocumentFake('Fake', ['test' => 'bar']),
-            ],
-            ['index1']
+            ]
         );
     }
 
@@ -63,11 +63,11 @@ class BatchProcessorTest extends SapphireTest
 
         $processor = new BatchProcessor($config);
         $processor->removeDocuments(
+            'index1',
             [
                 new DocumentFake('Fake', ['test' => 'foo']),
                 new DocumentFake('Fake', ['test' => 'bar']),
-            ],
-            ['index1']
+            ]
         );
     }
 
@@ -91,11 +91,11 @@ class BatchProcessorTest extends SapphireTest
 
         $processor = new BatchProcessor($config);
         $processor->addDocuments(
+            'index1',
             [
                 new DocumentFake('Fake', ['test' => 'foo']),
                 new DocumentFake('Fake', ['test' => 'bar']),
-            ],
-            ['index1']
+            ]
         );
     }
 
@@ -119,11 +119,11 @@ class BatchProcessorTest extends SapphireTest
 
         $processor = new BatchProcessor($config);
         $processor->removeDocuments(
+            'index1',
             [
                 new DocumentFake('Fake', ['test' => 'foo']),
                 new DocumentFake('Fake', ['test' => 'bar']),
-            ],
-            ['index1']
+            ]
         );
     }
 

--- a/tests/Service/BatchProcessorTest.php
+++ b/tests/Service/BatchProcessorTest.php
@@ -19,7 +19,7 @@ class BatchProcessorTest extends SapphireTest
 
     public function testAddDocumentsSync(): void
     {
-        $config = $this->mockConfig();
+        $config = $this->mockConfig(true);
         $config->set('use_sync_jobs', true);
 
         $mock = $this->getMockBuilder(SyncJobRunner::class)
@@ -46,7 +46,7 @@ class BatchProcessorTest extends SapphireTest
 
     public function testRemoveDocumentsSync(): void
     {
-        $config = $this->mockConfig();
+        $config = $this->mockConfig(true);
         $config->set('use_sync_jobs', true);
 
         $mock = $this->getMockBuilder(SyncJobRunner::class)
@@ -73,7 +73,7 @@ class BatchProcessorTest extends SapphireTest
 
     public function testAddDocumentsQueued(): void
     {
-        $config = $this->mockConfig();
+        $config = $this->mockConfig(true);
         $config->set('use_sync_jobs', false);
 
         $mock = $this->getMockBuilder(QueuedJobService::class)
@@ -101,7 +101,7 @@ class BatchProcessorTest extends SapphireTest
 
     public function testRemoveDocumentsQueued(): void
     {
-        $config = $this->mockConfig();
+        $config = $this->mockConfig(true);
         $config->set('use_sync_jobs', false);
 
         $mock = $this->getMockBuilder(QueuedJobService::class)

--- a/tests/Service/IndexConfigurationTest.php
+++ b/tests/Service/IndexConfigurationTest.php
@@ -141,33 +141,33 @@ class IndexConfigurationTest extends SapphireTest
         $this->bootstrapIndexes();
         $config = IndexConfiguration::singleton();
 
-        $result = $config->getClassesForIndex('index1');
+        $result = $config->getIndexDataForSuffix('index1')->getClasses();
         $this->assertTrue(is_array($result));
         $this->assertCount(2, $result);
         $this->assertContains(DataObjectFake::class, $result);
         $this->assertContains(Member::class, $result);
 
-        $result = $config->getClassesForIndex('index2');
+        $result = $config->getIndexDataForSuffix('index2')->getClasses();
         $this->assertTrue(is_array($result));
         $this->assertCount(2, $result);
         $this->assertContains(DataObjectFake::class, $result);
         $this->assertContains(Controller::class, $result);
 
-        $result = $config->getClassesForIndex('index3');
+        $result = $config->getIndexDataForSuffix('index3')->getClasses();
         $this->assertTrue(is_array($result));
         $this->assertCount(1, $result);
         $this->assertContains(DataObjectSubclassFake::class, $result);
 
-        $result = $config->getClassesForIndex('index4');
+        $result = $config->getIndexDataForSuffix('index4')->getClasses();
         $this->assertTrue(is_array($result));
         $this->assertCount(1, $result);
         $this->assertContains(ModelData::class, $result);
 
-        $result = $config->getClassesForIndex('index5');
+        $result = $config->getIndexDataForSuffix('index5')->getClasses();
         $this->assertTrue(is_array($result));
         $this->assertEmpty($result);
 
-        $result = $config->getClassesForIndex('index6');
+        $result = $config->getIndexDataForSuffix('index6')->getClasses();
         $this->assertTrue(is_array($result));
         $this->assertEmpty($result);
     }
@@ -283,48 +283,40 @@ class IndexConfigurationTest extends SapphireTest
         $this->bootstrapIndexes();
         $config = IndexConfiguration::singleton();
 
-        $result = $config->getFieldsForIndex('index1');
+        $result = $config->getIndexDataForSuffix('index1')->getFields();
         $names = array_map(function (Field $field) {
             return $field->getSearchFieldName();
         }, $result);
-        $this->assertCount(8, $names);
+        $this->assertCount(6, $names);
         $this->assertContains($config->getSourceClassField(), $names);
         $this->assertContains(DataObjectDocument::config()->get('base_class_field'), $names);
         $this->assertContains(DataObjectDocument::config()->get('record_id_field'), $names);
+        $this->assertContains('field1', $names);
         $this->assertContains('field2', $names);
         $this->assertContains('field3', $names);
-        $this->assertContains('field5', $names);
-        $this->assertContains('field9', $names);
 
-        $result = $config->getFieldsForIndex('index2');
+        $result = $config->getIndexDataForSuffix('index2')->getFields();
         $names = array_map(function (Field $field) {
             return $field->getSearchFieldName();
         }, $result);
-        $this->assertCount(8, $names);
+        $this->assertCount(5, $names);
         $this->assertContains($config->getSourceClassField(), $names);
         $this->assertContains(DataObjectDocument::config()->get('base_class_field'), $names);
         $this->assertContains(DataObjectDocument::config()->get('record_id_field'), $names);
-        $this->assertContains('field1', $names);
-        $this->assertContains('field2', $names);
+        $this->assertContains('field5', $names);
         $this->assertContains('field6', $names);
-        $this->assertContains('field5', $names);
-        $this->assertContains('field9', $names);
 
-        $result = $config->getFieldsForIndex('index3');
+        $result = $config->getIndexDataForSuffix('index3')->getFields();
         $names = array_map(function (Field $field) {
             return $field->getSearchFieldName();
         }, $result);
-        $this->assertCount(8, $names);
+        $this->assertCount(4, $names);
         $this->assertContains($config->getSourceClassField(), $names);
         $this->assertContains(DataObjectDocument::config()->get('base_class_field'), $names);
         $this->assertContains(DataObjectDocument::config()->get('record_id_field'), $names);
-        $this->assertContains('field1', $names);
-        $this->assertContains('field2', $names);
-        $this->assertContains('field5', $names);
         $this->assertContains('field7', $names);
-        $this->assertContains('field9', $names);
 
-        $result = $config->getFieldsForIndex('index4');
+        $result = $config->getIndexDataForSuffix('index4')->getFields();
         $names = array_map(function (Field $field) {
             return $field->getSearchFieldName();
         }, $result);
@@ -334,7 +326,7 @@ class IndexConfigurationTest extends SapphireTest
         $this->assertContains(DataObjectDocument::config()->get('record_id_field'), $names);
         $this->assertContains('field9', $names);
 
-        $result = $config->getFieldsForIndex('index5');
+        $result = $config->getIndexDataForSuffix('index5')->getFields();
         $names = array_map(function (Field $field) {
             return $field->getSearchFieldName();
         }, $result);
@@ -343,7 +335,7 @@ class IndexConfigurationTest extends SapphireTest
         $this->assertContains(DataObjectDocument::config()->get('base_class_field'), $names);
         $this->assertContains(DataObjectDocument::config()->get('record_id_field'), $names);
 
-        $result = $config->getFieldsForIndex('index6');
+        $result = $config->getIndexDataForSuffix('index6')->getFields();
         $names = array_map(function (Field $field) {
             return $field->getSearchFieldName();
         }, $result);
@@ -359,8 +351,6 @@ class IndexConfigurationTest extends SapphireTest
         $config = IndexConfiguration::singleton();
 
         $this->assertEquals(50, $config->getLowestBatchSizeForClass(Member::class));
-        // Should be the batch_size set specifically within index1
-        $this->assertEquals(75, $config->getLowestBatchSizeForClass(DataObjectFake::class, 'index1'));
         // Should pick the lowest defined batch_size across all of our indexes
         $this->assertEquals(50, $config->getLowestBatchSizeForClass(DataObjectFake::class));
         // Should not get mixed up with the definitions for DataObjectFake
@@ -376,8 +366,6 @@ class IndexConfigurationTest extends SapphireTest
         $config->restrictToIndexes(['index1']);
 
         $this->assertEquals(50, $config->getLowestBatchSizeForClass(Member::class));
-        // Should be the batch_size set specifically within index1
-        $this->assertEquals(75, $config->getLowestBatchSizeForClass(DataObjectFake::class, 'index1'));
         // Should be exactly the same as above, because we have filtered restrictToIndexes() to 'index1'
         $this->assertEquals(75, $config->getLowestBatchSizeForClass(DataObjectFake::class));
         // Should use batch_size for DataObjectFake, since DataObjectSubclassFake doesn't have an explicit definition
@@ -432,7 +420,7 @@ class IndexConfigurationTest extends SapphireTest
 
         $config = IndexConfiguration::singleton();
         $this->expectException(IndexConfigurationException::class);
-        $config->getFieldsForIndex('index5');
+        $config->getIndexDataForSuffix('index5')->getFields();
     }
 
     public function testGetIndexSuffixes(): void

--- a/tests/Service/IndexDataTest.php
+++ b/tests/Service/IndexDataTest.php
@@ -1,0 +1,264 @@
+<?php
+
+namespace SilverStripe\Forager\Tests\Service;
+
+use SilverStripe\Forager\Exception\IndexConfigurationException;
+use SilverStripe\Forager\Interfaces\IndexDataContextProvider;
+use SilverStripe\Forager\Service\IndexConfiguration;
+use SilverStripe\Forager\Service\IndexData;
+use SilverStripe\Forager\Tests\Fake\DataObjectFake;
+use SilverStripe\Forager\Tests\Fake\DataObjectSubclassFake;
+use SilverStripe\Forager\Tests\Fake\IndexConfigurationFake;
+use SilverStripe\Dev\SapphireTest;
+use SilverStripe\Core\Injector\Injector;
+use SilverStripe\Forager\Tests\SearchServiceTestTrait;
+
+class IndexDataTest extends SapphireTest
+{
+    use SearchServiceTestTrait;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->mockConfig(true);
+    }
+
+    public function testGetData(): void
+    {
+        $config = ['foo' => 'bar'];
+        $indexData = new IndexData($config, 'foo');
+
+        $this->assertEquals($config, $indexData->getData());
+    }
+
+    public function testGetSuffix(): void
+    {
+        $indexData = new IndexData([], 'bar');
+
+        $this->assertEquals('bar', $indexData->getSuffix());
+    }
+
+    public function testGetClassData(): void
+    {
+        $config = [
+            'includeClasses' => [
+                DataObjectFake::class => [
+                    'fields' => [
+                        'Title' => [
+                            'property' => 'Title',
+                        ],
+                    ],
+                ],
+            ],
+        ];
+
+        $indexData = new IndexData($config, 'foo');
+
+        $this->assertCount(1, $indexData->getClassData());
+        $this->assertArrayHasKey(DataObjectFake::class, $indexData->getClassData());
+    }
+
+    public function testGetClassConfig(): void
+    {
+        $config = [
+            'includeClasses' => [
+                DataObjectFake::class => [
+                    'fields' => [
+                        'Title' => [
+                            'property' => 'Title',
+                        ],
+                    ],
+                ],
+            ],
+        ];
+
+        $indexData = new IndexData($config, 'foo');
+
+        $this->assertNull($indexData->getClassConfig('non-existent'));
+        $this->assertIsArray($indexData->getClassConfig(DataObjectFake::class));
+    }
+
+    public function testGetClasses(): void
+    {
+        $config = [
+            'includeClasses' => [
+                DataObjectFake::class => [
+                    'fields' => [
+                        'Title' => [
+                            'property' => 'Title',
+                        ],
+                    ],
+                ],
+                DataObjectSubclassFake::class => false,
+            ],
+        ];
+
+        $indexData = new IndexData($config, 'foo');
+
+        $this->assertEquals([DataObjectFake::class], $indexData->getClasses());
+    }
+
+    public function testGetContextKey(): void
+    {
+        $indexData = new IndexData([], 'foo');
+        $this->assertEquals(IndexData::CONTEXT_KEY_DEFAULT, $indexData->getContextKey());
+
+        $indexData = new IndexData([IndexData::CONTEXT_KEY => 'bar'], 'foo');
+        $this->assertEquals('bar', $indexData->getContextKey());
+    }
+
+    public function testWithIndexContext(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+
+        $indexData = new IndexData([], 'foo');
+        $indexData->withIndexContext(function () {
+            //
+        });
+
+        $provider = $this->createMock(IndexDataContextProvider::class);
+        $provider->expects($this->once())->method('getContext')->willReturn(function (callable $next) {
+            return $next();
+        });
+
+        $indexData = new IndexData([IndexData::CONTEXT_KEY => 'bar'], 'foo');
+        $indexData->contexts = [
+            'bar' => [
+                $provider,
+            ],
+        ];
+
+        $called = false;
+        $indexData->withIndexContext(function () use (&$called) {
+            $called = true;
+        });
+
+        $this->assertTrue($called, 'Callback was not executed');
+    }
+
+    public function testGetFields(): void
+    {
+        $config = [
+            'includeClasses' => [
+                DataObjectFake::class => [
+                    'fields' => [
+                        'Title' => [
+                            'property' => 'Title',
+                        ],
+                    ],
+                ],
+            ],
+        ];
+
+        $indexData = new IndexData($config, 'foo');
+        $fields = $indexData->getFields();
+
+        $this->assertArrayHasKey('Title', $fields);
+        $this->assertArrayHasKey('source_class', $fields);
+        $this->assertArrayHasKey('record_base_class', $fields);
+        $this->assertArrayHasKey('record_id', $fields);
+    }
+
+    public function testGetFieldsForClass(): void
+    {
+        $config = [
+            'includeClasses' => [
+                DataObjectFake::class => [
+                    'fields' => [
+                        'Title' => [
+                            'property' => 'Title',
+                        ],
+                    ],
+                ],
+                DataObjectSubclassFake::class => [
+                    'fields' => [
+                        'Name' => [
+                            'property' => 'Name',
+                        ],
+                    ],
+                ],
+            ],
+        ];
+
+        $indexData = new IndexData($config, 'foo');
+        $fields = $indexData->getFieldsForClass(DataObjectSubclassFake::class);
+
+        $this->assertArrayHasKey('Title', $fields);
+        $this->assertArrayHasKey('Name', $fields);
+    }
+
+    public function testGetFieldsForClassThrowsException(): void
+    {
+        $this->expectException(IndexConfigurationException::class);
+
+        $config = [
+            'includeClasses' => [
+                DataObjectFake::class => [
+                    'fields' => [
+                        'Title' => [
+                            'property' => 'Title',
+                            'type' => 'string',
+                        ],
+                    ],
+                ],
+            ],
+        ];
+
+        $indexData = new IndexData($config, 'foo');
+        $indexData->getFieldsForClass(DataObjectFake::class);
+    }
+
+    public function testGetLowestBatchSize(): void
+    {
+        $config = [
+            'includeClasses' => [
+                DataObjectFake::class => [
+                    'batch_size' => 100,
+                ],
+                DataObjectSubclassFake::class => [
+                    'batch_size' => 50,
+                ],
+            ],
+        ];
+
+        $indexData = new IndexData($config, 'foo');
+        $this->assertEquals(50, $indexData->getLowestBatchSize());
+
+        $config = [
+            'includeClasses' => [
+                DataObjectFake::class => [],
+            ],
+        ];
+
+        $indexData = new IndexData($config, 'foo');
+        $this->assertEquals(100, $indexData->getLowestBatchSize());
+    }
+
+    public function testGetLowestBatchSizeForClass(): void
+    {
+        $config = [
+            'includeClasses' => [
+                DataObjectFake::class => [
+                    'batch_size' => 100,
+                ],
+                DataObjectSubclassFake::class => [
+                    'batch_size' => 50,
+                ],
+            ],
+        ];
+
+        $indexData = new IndexData($config, 'foo');
+        $this->assertEquals(50, $indexData->getLowestBatchSizeForClass(DataObjectSubclassFake::class));
+
+        $config = [
+            'includeClasses' => [
+                DataObjectFake::class => [],
+            ],
+        ];
+
+        $indexData = new IndexData($config, 'foo');
+        $this->assertEquals(100, $indexData->getLowestBatchSizeForClass(DataObjectFake::class));
+    }
+
+}

--- a/tests/Service/IndexerTest.php
+++ b/tests/Service/IndexerTest.php
@@ -19,21 +19,16 @@ class IndexerTest extends SapphireTest
 
     public function testConstructor(): void
     {
-        $indexSuffixes = [
-                'index1',
-                'index2',
-            ];
-
         $config = $this->mockConfig();
         $config->set('batch_size', 7);
         $indexer = Indexer::create(
-            [new DocumentFake('Fake'), new DocumentFake('Fake')],
-            $indexSuffixes
+            'index1',
+            [new DocumentFake('Fake'), new DocumentFake('Fake')]
         );
         $this->assertCount(2, $indexer->getDocuments());
         $this->assertEquals(Indexer::METHOD_ADD, $indexer->getMethod());
         $this->assertEquals(7, $indexer->getBatchSize());
-        $this->assertEquals($indexSuffixes, $indexer->getIndexSuffixes());
+        $this->assertEquals('index1', $indexer->getIndexSuffix());
     }
 
     public function testChunking(): void
@@ -46,7 +41,7 @@ class IndexerTest extends SapphireTest
             $docs[] = new DocumentFake('Fake');
         }
 
-        $indexer = Indexer::create($docs, ['index1', 'index2']);
+        $indexer = Indexer::create('index1', $docs);
         $this->assertEquals(3, $indexer->getChunkCount());
         $docs[] = new DocumentFake('Fake');
         $docs[] = new DocumentFake('Fake');
@@ -79,7 +74,7 @@ class IndexerTest extends SapphireTest
 
         $docs[0]->index = false;
 
-        $indexer = Indexer::create($docs, ['index1', 'index2']);
+        $indexer = Indexer::create('index1', $docs);
         $indexer->setIndexService($service = new ServiceFake());
 
         $this->assertEquals(3, $indexer->getChunkCount());
@@ -110,7 +105,7 @@ class IndexerTest extends SapphireTest
             $docs[] = new DocumentFake('Fake', ['id' => 'node-' . $i]);
         }
 
-        $indexer = Indexer::create($docs, ['index1', 'index2']);
+        $indexer = Indexer::create('index1', $docs);
         $indexer->setIndexService($service = new ServiceFake());
         $indexer->setBatchSize(50);
         $indexer->processNode();
@@ -173,7 +168,7 @@ class IndexerTest extends SapphireTest
             $blog1,
             $blog2,
         ];
-        $indexer = Indexer::create($tagDocs, ['index1', 'index2']);
+        $indexer = Indexer::create('index1', $tagDocs);
         $indexer->processNode();
         $this->assertTrue($indexer->finished());
 
@@ -183,7 +178,7 @@ class IndexerTest extends SapphireTest
 
         $blog1->index = false;
 
-        $indexer = Indexer::create($tagDocs, ['index1', 'index2']);
+        $indexer = Indexer::create('index1', $tagDocs);
         $indexer->processNode();
         $this->assertTrue($indexer->finished());
 

--- a/tests/Tasks/SearchReindexTest.php
+++ b/tests/Tasks/SearchReindexTest.php
@@ -38,18 +38,16 @@ class SearchReindexTest extends SapphireTest
         /** @var QueuedJobDescriptor[] $jobDescriptors */
         $jobDescriptors = QueuedJobDescriptor::get()->column('SavedJobData');
 
-        // 2 indexes, 1 has 3 defined classes, the other has 2 defined classes = 5 jobs total
-        $this->assertCount(5, $jobDescriptors);
+        // 2 indexes, 1 has 2 defined classes, the other has 1 defined class = 3 jobs total
+        $this->assertCount(3, $jobDescriptors);
 
         $expected = [
             'index1' => [
                 DataObjectFake::class,
                 DataObjectFakeAlternate::class,
-                Member::class,
             ],
             'index2' => [
                 DataObjectFake::class,
-                Controller::class,
             ],
         ];
 


### PR DESCRIPTION
These changes are really focused around one key idea:
* We want to process Documents for **one single index** at a time
* The index suffix is now the "most important" argument to be provided in any of these methods