### PR TITLE
HOTFIX revert identifier to baseclass

### DIFF
--- a/src/DataObject/DataObjectDocument.php
+++ b/src/DataObject/DataObjectDocument.php
@@ -126,7 +126,7 @@ class DataObjectDocument implements
     public function getIdentifier(): string
     {
         // generate the identifier from the base class and ID
-        $type = str_replace('\\', '_', $this->getSourceClass());
+        $type = str_replace('\\', '_', $this->getBaseClass());
         $id = $this->id;
 
         return strtolower(sprintf('%s_%s', $type, $id));

--- a/tests/DataObject/DataObjectDocumentTest.php
+++ b/tests/DataObject/DataObjectDocumentTest.php
@@ -65,6 +65,13 @@ class DataObjectDocumentTest extends SearchServiceTest
         $this->assertEquals('silverstripe_forager_tests_fake_dataobjectfake_5', $doc->getIdentifier());
     }
 
+    public function testGetIdentifierForSubClass(): void
+    {
+        $dataobject = new PageFake(['ID' => 5]);
+        $doc = DataObjectDocument::create($dataobject);
+        $this->assertEquals('silverstripe_cms_model_sitetree_5', $doc->getIdentifier());
+    }
+
     public function testGetSourceClass(): void
     {
         $dataobject = new DataObjectFake(['ID' => 5]);


### PR DESCRIPTION
# Description

To be confirmed: which branch/release to point this hotfix PR ?

It has been identified that the `getIdentifier` function was updated and changed to use the class name of the dataobject instead of the base class (see https://github.com/silverstripeltd/silverstripe-forager/pull/34/files#diff-b13876c606a1a9652add34a4b5330b6239fabef9c48c419943fb829bdeeb404fR122). Whilst for clean indexes this would most likely be fine, reindexing a subclassed page with this change will result in duplicate copies of the same object (except indexed under differing search IDs).

This change reverts back to using the base class for generating these IDs. To support deletion of non-versioned data objects, the base class value needs adding to the serialised data object for storing on the job so that it can be accessed after the data object has been deleted.

I've also added an additional `getIdentifier` test for a subclass page, to make sure the identifier uses the parent class.